### PR TITLE
feat: add generation of status map for spid identity provider

### DIFF
--- a/dev-console/src/idps/IdpEdit.tsx
+++ b/dev-console/src/idps/IdpEdit.tsx
@@ -308,34 +308,11 @@ const IdpEditForm = () => {
                     />
                     <RecordContextProvider value={config}>
                         <Stack direction={'column'}>
-                            {/*{Object.keys(config.statusMap).map(e => (
+                            {Object.keys(config.statusMap).map(e => (
                                 <Labeled>
                                     <IdField source={'statusMap.' + e} />
                                 </Labeled>
-                            ))}*/}
-                            {Object.entries(config.statusMap).map(([key, value]) => {
-                                if (key === 'identityProvidersUrl') return null;
-                                return (
-                                    <Labeled>
-                                         <IdField source={'statusMap.' + ([key, value])} />
-                                    </Labeled>
-                                );
-                            })}
-                            {config.statusMap.identityProvidersUrl &&
-                                Object.entries(config.statusMap.identityProvidersUrl).map(([key, value]) => (
-                                    <Labeled>
-                                        <IdField source={'statusMap.identityProvidersUrl:  ' + ([key, value])}/>
-                                    </Labeled>
-                                ))
-                            }
-                            {config.statusMap.identityProvidersUrl &&
-                                Object.entries(config.statusMap.identityProvidersUrl).map(([key, value]) => (
-                                    <div>
-                                        <p>Identity Provider:  {key}</p>
-                                        <p>URL:  {value}</p>
-                                    </div>
-                                ))
-                            }
+                            ))}
                         </Stack>
                     </RecordContextProvider>
                 </TabbedForm.Tab>

--- a/dev-console/src/idps/IdpEdit.tsx
+++ b/dev-console/src/idps/IdpEdit.tsx
@@ -308,11 +308,34 @@ const IdpEditForm = () => {
                     />
                     <RecordContextProvider value={config}>
                         <Stack direction={'column'}>
-                            {Object.keys(config.statusMap).map(e => (
+                            {/*{Object.keys(config.statusMap).map(e => (
                                 <Labeled>
                                     <IdField source={'statusMap.' + e} />
                                 </Labeled>
-                            ))}
+                            ))}*/}
+                            {Object.entries(config.statusMap).map(([key, value]) => {
+                                if (key === 'identityProvidersUrl') return null;
+                                return (
+                                    <Labeled>
+                                         <IdField source={'statusMap.' + ([key, value])} />
+                                    </Labeled>
+                                );
+                            })}
+                            {config.statusMap.identityProvidersUrl &&
+                                Object.entries(config.statusMap.identityProvidersUrl).map(([key, value]) => (
+                                    <Labeled>
+                                        <IdField source={'statusMap.identityProvidersUrl:  ' + ([key, value])}/>
+                                    </Labeled>
+                                ))
+                            }
+                            {config.statusMap.identityProvidersUrl &&
+                                Object.entries(config.statusMap.identityProvidersUrl).map(([key, value]) => (
+                                    <div>
+                                        <p>Identity Provider:  {key}</p>
+                                        <p>URL:  {value}</p>
+                                    </div>
+                                ))
+                            }
                         </Stack>
                     </RecordContextProvider>
                 </TabbedForm.Tab>

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityConfigurationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityConfigurationProvider.java
@@ -62,6 +62,7 @@ public class SpidIdentityConfigurationProvider
         //  Check architecture and relationship with IdentityAuthority
         if (this.localRegistry != null) {
             spidConfig.setIdentityProviders(this.localRegistry);
+            spidConfig.setBaseUrl(applicationProperties.getUrl());
         }
         return spidConfig;
     }

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -105,7 +105,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         if (statusMap == null) {
             statusMap = new SpidIdentityProviderStatusMap();
             statusMap.setMetadataUrl(getMetadataUrl());
-            statusMap.setAssertionConsumerUrl(getAssertionConsumerUrl());
+            statusMap.setIdentityProvidersUrl(getIdentityProvidersUrl());
         }
         return statusMap;
     }
@@ -113,34 +113,32 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     public String getMetadataUrl() {
         if (baseUrl != null) {
             UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(metadataUrlTemplate());
-            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "metadataRegistrationId", getMetadataRegistrationId())).toUriString();
+            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", getMetadataRegistrationId())).toUriString();
         }
         return null;
     }
 
     public String metadataUrlTemplate() {
-        return "{baseUrl}/auth/" + getAuthority() + "/metadata/{metadataRegistrationId}";
+        return "{baseUrl}/auth/" + getAuthority() + "/metadata/{registrationId}";
     }
 
-    public String getAssertionConsumerUrl() {
+    public Map<String, String> getIdentityProvidersUrl(){
         if (baseUrl != null) {
-            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(assertionConsumerUrlTemplate());
-            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", getProvider())).toUriString();
+            Map<String, String> identityProvidersUrl = new HashMap<>();
+            for(RelyingPartyRegistration relyingPartyRegistration : getUpstreamRelyingPartyRegistrations()){
+                identityProvidersUrl.put(
+                        relyingPartyRegistration.getProviderDetails().getEntityId(),
+                        UriComponentsBuilder.fromUriString(identityProviderUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "relyingPartyRegistrationId",  relyingPartyRegistration.getRegistrationId())).toUriString());
+            }
+            return identityProvidersUrl;
         }
         return null;
     }
 
-    public String assertionConsumerUrlTemplate() {
-        return "{baseUrl}/auth/" + getAuthority() + "/sso/{registrationId}";
+    public String identityProviderUrlTemplate() {
+        return "{baseUrl}/auth/" + getAuthority() + "/authenticate/{relyingPartyRegistrationId}";
     }
 
-    public String getConsumerUrl() {
-        return baseUrl + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
-    }
-
-    public String getLogoutUrl() {
-        return baseUrl + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
-    }
     /*
      * Extract a provider from a registration with pattern either {providerId}
      * or {providerId}|{idpKey} where idpKey is the key of the upstream
@@ -282,6 +280,14 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return getProvider() + "|" + idpKeyIdentifier;
     }
 
+    public String getConsumerUrl() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
+    }
+
+    public String getLogoutUrl() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
+    }
+
     // create a relying party registration for an upstream idp; only ap autoconfiguration
     // is supported, hence function parameters require an idp metadata url
     private RelyingPartyRegistration toRelyingPartyRegistration(String idpMetadataUrl)
@@ -317,6 +323,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return builder.build();
     }
 
+    @JsonIgnore
     public List<Credential> getRelyingPartySigningCredentials() {
         List<Credential> credentials = new ArrayList<>();
         RelyingPartyRegistration rp = getRelyingPartyRegistrations().stream().findFirst().orElse(null);
@@ -385,6 +392,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
      * This is required for cases where the registration does not require any asserting party details,
      * such as SPID metadata.
      */
+    @JsonIgnore
     public RelyingPartyRegistration getRelyingPartyRegistration() {
         return getRelyingPartyRegistrations()
             .stream()

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -317,7 +317,6 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return builder.build();
     }
 
-    @JsonIgnore
     public List<Credential> getRelyingPartySigningCredentials() {
         List<Credential> credentials = new ArrayList<>();
         RelyingPartyRegistration rp = getRelyingPartyRegistrations().stream().findFirst().orElse(null);
@@ -386,7 +385,6 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
      * This is required for cases where the registration does not require any asserting party details,
      * such as SPID metadata.
      */
-    @JsonIgnore
     public RelyingPartyRegistration getRelyingPartyRegistration() {
         return getRelyingPartyRegistrations()
             .stream()

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -47,6 +47,7 @@ import org.springframework.security.saml2.provider.service.registration.RelyingP
 import org.springframework.security.saml2.provider.service.registration.Saml2MessageBinding;
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
+import org.springframework.web.util.UriComponentsBuilder;
 
 public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<SpidIdentityProviderConfigMap> {
 
@@ -63,6 +64,8 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
 
     private transient Set<RelyingPartyRegistration> relyingPartyRegistrations; // first time evaluated by the getter, then immutable
     private Map<String, SpidRegistration> identityProviders; // local registry
+    private transient SpidIdentityProviderStatusMap statusMap;
+    private String baseUrl;
 
     public SpidIdentityProviderConfig(String provider, String realm) {
         super(
@@ -94,6 +97,50 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         super();
     }
 
+    public void setBaseUrl(String baseUrl) {
+        this.baseUrl = baseUrl;
+    }
+
+    public SpidIdentityProviderStatusMap getStatusMap() {
+        if (statusMap == null) {
+            statusMap = new SpidIdentityProviderStatusMap();
+            statusMap.setMetadataUrl(getMetadataUrl());
+            statusMap.setAssertionConsumerUrl(getAssertionConsumerUrl());
+        }
+        return statusMap;
+    }
+
+    public String getMetadataUrl() {
+        if (baseUrl != null) {
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(metadataUrlTemplate());
+            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "metadataRegistrationId", getMetadataRegistrationId())).toUriString();
+        }
+        return null;
+    }
+
+    public String metadataUrlTemplate() {
+        return "{baseUrl}/auth/" + getAuthority() + "/metadata/{metadataRegistrationId}";
+    }
+
+    public String getAssertionConsumerUrl() {
+        if (baseUrl != null) {
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(assertionConsumerUrlTemplate());
+            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", getProvider())).toUriString();
+        }
+        return null;
+    }
+
+    public String assertionConsumerUrlTemplate() {
+        return "{baseUrl}/auth/" + getAuthority() + "/sso/{registrationId}";
+    }
+
+    public String getConsumerUrl() {
+        return baseUrl + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
+    }
+
+    public String getLogoutUrl() {
+        return baseUrl + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
+    }
     /*
      * Extract a provider from a registration with pattern either {providerId}
      * or {providerId}|{idpKey} where idpKey is the key of the upstream
@@ -233,18 +280,6 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     private String evalRelyingPartyRegistrationId(String idpKeyIdentifier) {
         // NOTE: this function is 'inverted' by getProviderId(..)
         return getProvider() + "|" + idpKeyIdentifier;
-    }
-
-    public String getConsumerUrl() {
-        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
-    }
-
-    public String getLogoutUrl() {
-        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
-    }
-
-    public String getMetadataUrl() {
-        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "metadata/" + getMetadataRegistrationId();
     }
 
     // create a relying party registration for an upstream idp; only ap autoconfiguration

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -127,10 +127,10 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         if (baseUrl != null) {
             Map<String, String> assertionConsumerUrls = new HashMap<>();
             for(RelyingPartyRegistration relyingPartyRegistration : getUpstreamRelyingPartyRegistrations()){
-                if(relyingPartyRegistration.getProviderDetails().getEntityId() != null) {
+                if(relyingPartyRegistration.getProviderDetails() != null) {
                     assertionConsumerUrls.put(
                             relyingPartyRegistration.getProviderDetails().getEntityId(),
-                            UriComponentsBuilder.fromUriString(identityProviderUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", relyingPartyRegistration.getRegistrationId())).toUriString());
+                            UriComponentsBuilder.fromUriString(assertionConsumerUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", relyingPartyRegistration.getRegistrationId())).toUriString());
                     }
                 }
             return assertionConsumerUrls;
@@ -138,7 +138,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return null;
     }
 
-    public String identityProviderUrlTemplate() {
+    public String assertionConsumerUrlTemplate() {
         return "{baseUrl}/auth/" + getAuthority() + "/authenticate/{registrationId}";
     }
 

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -103,9 +103,10 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
 
     public SpidIdentityProviderStatusMap getStatusMap() {
         if (statusMap == null) {
+
             statusMap = new SpidIdentityProviderStatusMap();
             statusMap.setMetadataUrl(getMetadataUrl());
-            statusMap.setIdentityProvidersUrl(getIdentityProvidersUrl());
+            statusMap.setAssertionConsumerUrls(getAssertionConsumerUrls());
         }
         return statusMap;
     }
@@ -122,21 +123,23 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return "{baseUrl}/auth/" + getAuthority() + "/metadata/{registrationId}";
     }
 
-    public Map<String, String> getIdentityProvidersUrl(){
+    public Map<String, String> getAssertionConsumerUrls(){
         if (baseUrl != null) {
-            Map<String, String> identityProvidersUrl = new HashMap<>();
+            Map<String, String> assertionConsumerUrls = new HashMap<>();
             for(RelyingPartyRegistration relyingPartyRegistration : getUpstreamRelyingPartyRegistrations()){
-                identityProvidersUrl.put(
-                        relyingPartyRegistration.getProviderDetails().getEntityId(),
-                        UriComponentsBuilder.fromUriString(identityProviderUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "relyingPartyRegistrationId",  relyingPartyRegistration.getRegistrationId())).toUriString());
-            }
-            return identityProvidersUrl;
+                if(relyingPartyRegistration.getProviderDetails().getEntityId() != null) {
+                    assertionConsumerUrls.put(
+                            relyingPartyRegistration.getProviderDetails().getEntityId(),
+                            UriComponentsBuilder.fromUriString(identityProviderUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", relyingPartyRegistration.getRegistrationId())).toUriString());
+                    }
+                }
+            return assertionConsumerUrls;
         }
         return null;
     }
 
     public String identityProviderUrlTemplate() {
-        return "{baseUrl}/auth/" + getAuthority() + "/authenticate/{relyingPartyRegistrationId}";
+        return "{baseUrl}/auth/" + getAuthority() + "/authenticate/{registrationId}";
     }
 
     /*

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
@@ -42,14 +42,14 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
         SystemKeys.AUTHORITY_SPID;
 
     private String metadataUrl;
-    private String assertionConsumerUrl;
+    private Map<String, String> identityProvidersUrl;
 
-    public String getAssertionConsumerUrl() {
-        return assertionConsumerUrl;
+    public Map<String, String> getIdentityProvidersUrl() {
+        return identityProvidersUrl;
     }
 
-    public void setAssertionConsumerUrl(String assertionConsumerUrl) {
-        this.assertionConsumerUrl = assertionConsumerUrl;
+    public void setIdentityProvidersUrl(Map<String, String> identityProvidersUrl) {
+        this.identityProvidersUrl = identityProvidersUrl;
     }
 
     public String getMetadataUrl() {
@@ -65,7 +65,7 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
     @JsonIgnore
     public void setConfiguration(SpidIdentityProviderStatusMap map) {
         this.metadataUrl = map.getMetadataUrl();
-        this.assertionConsumerUrl = map.getAssertionConsumerUrl();
+        this.identityProvidersUrl = map.getIdentityProvidersUrl();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
@@ -42,14 +42,14 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
         SystemKeys.AUTHORITY_SPID;
 
     private String metadataUrl;
-    private Map<String, String> identityProvidersUrl;
+    private Map<String, String> assertionConsumerUrls;
 
-    public Map<String, String> getIdentityProvidersUrl() {
-        return identityProvidersUrl;
+    public Map<String, String> getAssertionConsumerUrls() {
+        return assertionConsumerUrls;
     }
 
-    public void setIdentityProvidersUrl(Map<String, String> identityProvidersUrl) {
-        this.identityProvidersUrl = identityProvidersUrl;
+    public void setAssertionConsumerUrls(Map<String, String> assertionConsumerUrls) {
+        this.assertionConsumerUrls = assertionConsumerUrls;
     }
 
     public String getMetadataUrl() {
@@ -65,7 +65,7 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
     @JsonIgnore
     public void setConfiguration(SpidIdentityProviderStatusMap map) {
         this.metadataUrl = map.getMetadataUrl();
-        this.identityProvidersUrl = map.getIdentityProvidersUrl();
+        this.assertionConsumerUrls = map.getAssertionConsumerUrls();
     }
 
     @Override

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.smartcommunitylab.aac.spid.provider;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.module.jsonSchema.JsonSchema;
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.base.model.AbstractStatusMap;
+
+import javax.validation.Valid;
+import java.io.Serializable;
+import java.util.Map;
+
+@Valid
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
+
+    private static final long serialVersionUID = SystemKeys.AAC_SPID_SERIAL_VERSION;
+
+    public static final String RESOURCE_TYPE =
+        SystemKeys.RESOURCE_CONFIG +
+        SystemKeys.ID_SEPARATOR +
+        SystemKeys.RESOURCE_IDENTITY_PROVIDER +
+        SystemKeys.ID_SEPARATOR +
+        SystemKeys.AUTHORITY_SPID;
+
+    private String metadataUrl;
+    private String assertionConsumerUrl;
+
+    public String getAssertionConsumerUrl() {
+        return assertionConsumerUrl;
+    }
+
+    public void setAssertionConsumerUrl(String assertionConsumerUrl) {
+        this.assertionConsumerUrl = assertionConsumerUrl;
+    }
+
+    public String getMetadataUrl() {
+        return metadataUrl;
+    }
+
+    public void setMetadataUrl(String metadataUrl) {
+        this.metadataUrl = metadataUrl;
+    }
+
+    public SpidIdentityProviderStatusMap() {}
+
+    @JsonIgnore
+    public void setConfiguration(SpidIdentityProviderStatusMap map) {
+        this.metadataUrl = map.getMetadataUrl();
+        this.assertionConsumerUrl = map.getAssertionConsumerUrl();
+    }
+
+    @Override
+    public void setConfiguration(Map<String, Serializable> props) {
+        // use mapper
+        mapper.setSerializationInclusion(Include.NON_EMPTY);
+        SpidIdentityProviderStatusMap map = mapper.convertValue(props, SpidIdentityProviderStatusMap.class);
+
+        setConfiguration(map);
+    }
+
+    @JsonIgnore
+    public JsonSchema getSchema() throws JsonMappingException {
+        return schemaGen.generateSchema(SpidIdentityProviderStatusMap.class);
+    }
+}


### PR DESCRIPTION
This pull request closes the issue #661.
The functionality of the status screen, already present in saml, is added also in spid. This solution allows to display the metadata.xml link in status.