### PR TITLE
fix: configuration for the generation of JSON for IDP SPID

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -282,6 +282,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return builder.build();
     }
 
+    @JsonIgnore
     public List<Credential> getRelyingPartySigningCredentials() {
         List<Credential> credentials = new ArrayList<>();
         RelyingPartyRegistration rp = getRelyingPartyRegistrations().stream().findFirst().orElse(null);
@@ -350,6 +351,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
      * This is required for cases where the registration does not require any asserting party details,
      * such as SPID metadata.
      */
+    @JsonIgnore
     public RelyingPartyRegistration getRelyingPartyRegistration() {
         return getRelyingPartyRegistrations()
             .stream()


### PR DESCRIPTION
This pull request closes the issue #666.
Resolution for SPID IdP configuration JSON generation. Now the SPID keys are correctly handled.