### PR TITLE
feat: spid configurable AssertionConsumerService reference in SAML requests

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -659,6 +659,10 @@
         "name": "Spid user attributes",
         "helperText": "List of attribute names to be requested to Idp"
     },
+    "useAssertionConsumerServiceUrl": {
+        "name": "Use Assertion Consumer Service URL",
+        "helperText": "Enable to use the AssertionConsumerServiceURL attribute in the request instead of the AssertionConsumerServiceIndex attribute"
+    },
     "spidLevel": {
         "name": "Spid level",
         "helperText": "SPID authentication level"

--- a/dev-console/src/idps/schemas.ts
+++ b/dev-console/src/idps/schemas.ts
@@ -243,7 +243,7 @@ export const uiSchemaOpenidfedIdp: UiSchema = {
     },
 };
 export const uiSchemaSpidIdp: UiSchema = {
-    'ui:layout': [12, 6, 6, 6, 6, 12, 6, 6, 6, 6, 12, 12, 12, 12, 6, 6],
+    'ui:layout': [12, 6, 6, 6, 6, 12, 6, 6, 6, 6, 12, 12, 12, 12, 12, 6, 6],
     'ui:order': [
         'entityId',
         'signingKey',
@@ -258,6 +258,7 @@ export const uiSchemaSpidIdp: UiSchema = {
         'idps',
         'idpMetadataUrl',
         'spidAttributes',
+        'useAssertionConsumerServiceUrl',
         'authnContext',
         'subAttributeName',
         'usernameAttributeName',

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidAuthenticationRequestContextConverter.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidAuthenticationRequestContextConverter.java
@@ -171,16 +171,18 @@ public class SpidAuthenticationRequestContextConverter
 
         // assertion consuming
         // TODO: review with ACR
-        auth.setAssertionConsumerServiceIndex(0);
+        if (providerConfig.getUseAssertionConsumerServiceUrl()) {
+            auth.setProtocolBinding(protocolBinding);
+            auth.setAssertionConsumerServiceURL(context.getAssertionConsumerServiceUrl());
+        } else {
+            auth.setAssertionConsumerServiceIndex(0);
+        }
+        
         auth.setAttributeConsumingServiceIndex(0);
-        // If assertion consuming service index is not set, the following should be used instead
-        //        auth.setProtocolBinding(protocolBinding);
-        //        auth.setAssertionConsumerServiceURL(context.getAssertionConsumerServiceUrl());
 
         //        Scoping scoping = new ScopingBuilder().buildObject();
         //        scoping.setProxyCount(0);
         //        auth.setScoping(scoping);
         return auth;
-        //        return null;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -355,6 +355,12 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return configMap.getSpidAttributes() == null ? Collections.emptySet() : configMap.getSpidAttributes();
     }
 
+    public Boolean getUseAssertionConsumerServiceUrl() {
+        return configMap.getUseAssertionConsumerServiceUrl() != null
+            ? configMap.getUseAssertionConsumerServiceUrl()
+            : Boolean.FALSE;
+    }
+
     public Set<String> getRelyingPartyRegistrationAuthnContextClassRefs() {
         return configMap.getAuthnContext() == null
             ? Collections.emptySet()

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfigMap.java
@@ -30,8 +30,6 @@ import java.io.Serializable;
 import java.util.Map;
 import java.util.Set;
 import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 @Valid
@@ -80,6 +78,7 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
     private String idpMetadataUrl; // optional (see note above)
     private Set<SpidAttribute> spidAttributes; // optional
 
+    private Boolean useAssertionConsumerServiceUrl;
     private SpidAuthnContext authnContext;
 
     private SpidUserAttribute subAttributeName; // optional
@@ -189,6 +188,14 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.spidAttributes = spidAttributes;
     }
 
+    public Boolean getUseAssertionConsumerServiceUrl() {
+        return useAssertionConsumerServiceUrl;
+    }
+
+    public void setUseAssertionConsumerServiceUrl(Boolean useAssertionConsumerServiceUrl) {
+        this.useAssertionConsumerServiceUrl = useAssertionConsumerServiceUrl;
+    }
+
     public SpidAuthnContext getAuthnContext() {
         return authnContext;
     }
@@ -228,6 +235,7 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.idps = map.getIdps();
         this.idpMetadataUrl = map.getIdpMetadataUrl();
         this.spidAttributes = map.getSpidAttributes();
+        this.useAssertionConsumerServiceUrl = map.getUseAssertionConsumerServiceUrl();
         this.authnContext = map.getAuthnContext();
         this.subAttributeName = map.getSubAttributeName();
         this.usernameAttributeName = map.getUsernameAttributeName();


### PR DESCRIPTION
This pull request addresses #703 by adding the possibility to define the attribute to be used directly in the provider's configuration