### PR TITLE
feat: oidc identity provider configurable custom authn parameters

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -95,6 +95,18 @@
         "name": "Prompt Mode",
         "helperText": ""
     },
+    "customAuthNParameters": {
+        "name": "Custom AuthN Parameters",
+        "helperText": "Additional custom parameters to include in authN requests",
+        "parameterName": {
+            "name": "Parameter Name",
+            "helperText": ""
+        },
+        "parameterValue": {
+            "name": "Parameter Value",
+            "helperText": ""
+        }
+    },
     "template_override": {
         "name": "Template Override",
         "helperText": ""

--- a/dev-console/src/idps/schemas.ts
+++ b/dev-console/src/idps/schemas.ts
@@ -1,5 +1,18 @@
 import { RJSFSchema, UiSchema } from '@rjsf/utils';
 
+const fixIdsRecursive = (obj: any) => {
+    if (obj && typeof obj === "object") {
+        if ('id' in obj && typeof obj['id'] === 'string' && obj['id'].startsWith("urn:jsonschema:")) {
+            obj['$id'] = obj['id'];
+            delete obj['id'];
+        }
+        for (const key in obj) {
+            fixIdsRecursive(obj[key]);
+        }
+    }
+    return obj;
+};
+
 export const getIdpSchema = (schema?: any) => {
     if (!schema) {
         return {};
@@ -7,12 +20,7 @@ export const getIdpSchema = (schema?: any) => {
 
     //fix id definition
     //TODO update in backend
-    if ('id' in schema) {
-        schema['$id'] = schema['id'];
-        delete schema['id'];
-    }
-
-    return schema;
+    return fixIdsRecursive(schema);
 };
 
 export const getIdpUiSchema = (schema?: any) => {
@@ -117,10 +125,24 @@ export const uiSchemaAppleIdp: UiSchema = {
 };
 export const uiSchemaOidcIdp: UiSchema = {
     'ui:layout': [
-        12, 12, 12, 12, 6, 6, 12, 6, 6, 4, 4, 4, 12, 12, 12, 12, 12, 6, 6,
+        12, 12, 12, 12, 6, 6, 12, 6, 6, 4, 4, 4, 12, 12, 12, 12, 12, 6, 6, 12, 12
     ],
     clientJwk: {
         'ui:widget': 'textarea',
+    },
+    customAuthNParameters: {
+        items: {
+            'ui:layout': [6, 6],
+            'ui:order': ['name', 'value'],
+            name: {
+                'ui:title': 'field.customAuthNParameters.parameterName.name',
+                'ui:description': 'field.customAuthNParameters.parameterName.helperText',
+            },
+            value: {
+                'ui:title': 'field.customAuthNParameters.parameterValue.name',
+                'ui:description': 'field.customAuthNParameters.parameterValue.helperText',
+            },
+        },
     },
 };
 export const uiSchemaPasswordIdp: UiSchema = {

--- a/src/main/java/it/smartcommunitylab/aac/oidc/auth/ExtendedAuthorizationRequestResolver.java
+++ b/src/main/java/it/smartcommunitylab/aac/oidc/auth/ExtendedAuthorizationRequestResolver.java
@@ -27,6 +27,8 @@ import javax.servlet.http.HttpServletRequest;
 import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.core.endpoint.PkceParameterNames;
+import org.springframework.security.oauth2.core.oidc.endpoint.OidcParameterNames;
 import org.springframework.util.StringUtils;
 
 public class ExtendedAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
@@ -94,8 +96,8 @@ public class ExtendedAuthorizationRequestResolver implements OAuth2Authorization
     private void addCustomParameters(Set<CustomAuthNParameter> customParametes, Map<String, Object> additionalParameters, HttpServletRequest request) {
         // only parameters defined in the provider config can be added
         for (CustomAuthNParameter param : customParametes) {
-            if (!StringUtils.hasText(param.getName())) {
-                break;
+            if (!StringUtils.hasText(param.getName()) || !isCustomParameterAllowed(param.getName())) {
+                continue;
             }
 
             // resolve parameter value from request, otherwise use default from config if present
@@ -107,5 +109,20 @@ public class ExtendedAuthorizationRequestResolver implements OAuth2Authorization
                 additionalParameters.put(param.getName(), param.getValue());
             }
         }
+    }
+
+    private Boolean isCustomParameterAllowed(String name) {
+        // prevent overwriting standard parameters
+        Set<String> standardParams = Set.of(
+            OAuth2ParameterNames.CLIENT_ID,
+            OAuth2ParameterNames.RESPONSE_TYPE,
+            OAuth2ParameterNames.SCOPE,
+            OAuth2ParameterNames.STATE,
+            OAuth2ParameterNames.REDIRECT_URI,
+            PkceParameterNames.CODE_CHALLENGE,
+            PkceParameterNames.CODE_CHALLENGE_METHOD,
+            OidcParameterNames.NONCE
+        );
+        return !standardParams.contains(name);
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oidc/auth/ExtendedAuthorizationRequestResolver.java
+++ b/src/main/java/it/smartcommunitylab/aac/oidc/auth/ExtendedAuthorizationRequestResolver.java
@@ -19,6 +19,7 @@ package it.smartcommunitylab.aac.oidc.auth;
 import it.smartcommunitylab.aac.core.provider.ProviderConfigRepository;
 import it.smartcommunitylab.aac.oauth.model.PromptMode;
 import it.smartcommunitylab.aac.oidc.provider.OIDCIdentityProviderConfig;
+import it.smartcommunitylab.aac.oidc.provider.OIDCIdentityProviderConfigMap.CustomAuthNParameter;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -43,15 +44,15 @@ public class ExtendedAuthorizationRequestResolver implements OAuth2Authorization
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
-        return enhance(resolver.resolve(request));
+        return enhance(request, resolver.resolve(request));
     }
 
     @Override
     public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
-        return enhance(resolver.resolve(request, clientRegistrationId));
+        return enhance(request, resolver.resolve(request, clientRegistrationId));
     }
 
-    public OAuth2AuthorizationRequest enhance(OAuth2AuthorizationRequest authRequest) {
+    public OAuth2AuthorizationRequest enhance(HttpServletRequest request, OAuth2AuthorizationRequest authRequest) {
         if (authRequest == null) {
             return null;
         }
@@ -71,6 +72,10 @@ public class ExtendedAuthorizationRequestResolver implements OAuth2Authorization
             addPromptParameters(provider.getConfigMap().getPromptMode(), additionalParameters);
         }
 
+        if (provider.getConfigMap().getCustomAuthNParameters() != null) {
+            addCustomParameters(provider.getConfigMap().getCustomAuthNParameters(), additionalParameters, request);
+        }
+
         // get a builder and reset parameters
         return OAuth2AuthorizationRequest
             .from(authRequest)
@@ -83,6 +88,24 @@ public class ExtendedAuthorizationRequestResolver implements OAuth2Authorization
         String prompt = StringUtils.collectionToDelimitedString(promptMode, " ");
         if (StringUtils.hasText(prompt)) {
             additionalParameters.put("prompt", prompt);
+        }
+    }
+
+    private void addCustomParameters(Set<CustomAuthNParameter> customParametes, Map<String, Object> additionalParameters, HttpServletRequest request) {
+        // only parameters defined in the provider config can be added
+        for (CustomAuthNParameter param : customParametes) {
+            if (!StringUtils.hasText(param.getName())) {
+                break;
+            }
+
+            // resolve parameter value from request, otherwise use default from config if present
+            String value = request.getParameter(param.getName());
+
+            if (value != null) {
+                additionalParameters.put(param.getName(), value);
+            } else if (StringUtils.hasText(param.getValue())) {
+                additionalParameters.put(param.getName(), param.getValue());
+            }
         }
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oidc/provider/OIDCIdentityProviderConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oidc/provider/OIDCIdentityProviderConfigMap.java
@@ -72,6 +72,8 @@ public class OIDCIdentityProviderConfigMap extends AbstractConfigMap {
     private Boolean respectTokenExpiration;
     private Set<PromptMode> promptMode;
 
+    private Set<CustomAuthNParameter> customAuthNParameters;
+
     public OIDCIdentityProviderConfigMap() {}
 
     public String getClientId() {
@@ -234,6 +236,14 @@ public class OIDCIdentityProviderConfigMap extends AbstractConfigMap {
         this.promptMode = promptMode;
     }
 
+    public Set<CustomAuthNParameter> getCustomAuthNParameters() {
+        return customAuthNParameters;
+    }
+
+    public void setCustomParameters(Set<CustomAuthNParameter> customAuthNParameters) {
+        this.customAuthNParameters = customAuthNParameters;
+    }
+
     @JsonIgnore
     public void setConfiguration(OIDCIdentityProviderConfigMap map) {
         this.clientId = map.getClientId();
@@ -263,6 +273,8 @@ public class OIDCIdentityProviderConfigMap extends AbstractConfigMap {
         this.propagateEndSession = map.getPropagateEndSession();
         this.respectTokenExpiration = map.getRespectTokenExpiration();
         this.promptMode = map.getPromptMode();
+
+        this.customAuthNParameters = map.getCustomAuthNParameters();
     }
 
     @Override
@@ -277,5 +289,34 @@ public class OIDCIdentityProviderConfigMap extends AbstractConfigMap {
     @JsonIgnore
     public JsonSchema getSchema() throws JsonMappingException {
         return schemaGen.generateSchema(OIDCIdentityProviderConfigMap.class);
+    }
+
+    public static class CustomAuthNParameter implements Serializable {
+
+        private String name;
+        private String value;
+
+        public CustomAuthNParameter() { }
+
+        public CustomAuthNParameter(String name, String value){
+            this.name = name;
+            this.value = value;
+        }
+
+        public String getName() {
+            return this.name;
+        }
+
+        public void setName(String name){
+            this.name = name;
+        }
+
+        public String getValue() {
+            return this.value;
+        }
+
+        public void setValue(String value){
+            this.value = value;
+        }
     }
 }


### PR DESCRIPTION
This pull request addresses #706 by adding the possibility to configure custom parameters in the authentication request generated by an OIDC identity provider. In particular, parameters that are passed on must be defined in the configmap of the identity provider and their value can be defined as a default in the configmap itself or they can be retrieved from the request if defined for example in the button template of the identity provider.