### PR TITLE
feat: spid provider improvements

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -635,6 +635,14 @@
         "name": "AuthN Context Comparison",
         "helperText": ""
     },
+    "metadataUrl": {
+        "name": "Metadata URL",
+        "helperText": "If set, the metadata configuration will be loaded automatically and no local metadata will be exposed."
+    },
+    "metadataXML": {
+        "name": "Metadata XML",
+        "helperText": "If set, the metadata configuration will be loaded automatically and no local metadata will be exposed."
+    },
     "organizationDisplayName": {
         "name": "Organization Display Name",
         "helperText": "Organization information"
@@ -643,21 +651,17 @@
         "name": "Organization Url",
         "helperText": "Organization information"
     },
-    "contactPerson_EmailAddress": {
+    "contactPersonEmailAddress": {
         "name": "Contact person email",
-        "helperText": "Contact person information"
+        "helperText": "ContactPerson information"
     },
-    "contactPerson_IPACode": {
+    "contactPersonIPACode": {
         "name": "Contact person IPAcode",
-        "helperText": "Contact person information"
+        "helperText": "ContactPerson information"
     },
-    "contactPerson_Type": {
-        "name": "Contact person phone",
-        "helperText": "Contact person information"
-    },
-    "contactPerson_Public": {
-        "name": "Contact person Public",
-        "helperText": "Contact person information"
+    "spidAttributes": {
+        "name": "Spid user attributes",
+        "helperText": "List of attributes to be requested to Idp"
     },
     "idps": {
         "name": "Identity Providers",
@@ -667,13 +671,13 @@
         "name": "IdP Metadata Discovery URL",
         "helperText": "IdP Configuration"
     },
-    "spidAttributes": {
-        "name": "Spid user attributes",
-        "helperText": "List of attribute names to be requested to Idp"
-    },
     "useAssertionConsumerServiceUrl": {
         "name": "Use Assertion Consumer Service URL",
-        "helperText": "Enable to use the AssertionConsumerServiceURL attribute in the request instead of the AssertionConsumerServiceIndex attribute"
+        "helperText": "Use the AssertionConsumerServiceURL attribute in AuthN requests instead of the AssertionConsumerServiceIndex attribute"
+    },
+    "attributeConsumingServiceIndex": {
+        "name": "Attribute Consuming Service Index",
+        "helperText": "Index of the Attribute Consuming Service to use in AuthN requests"
     },
     "spidLevel": {
         "name": "Spid level",

--- a/dev-console/src/idps/IdpEdit.tsx
+++ b/dev-console/src/idps/IdpEdit.tsx
@@ -309,21 +309,21 @@ const IdpEditForm = () => {
                     <RecordContextProvider value={config}>
                         <Stack direction={'column'}>
                             {Object.entries(config.statusMap).map(([key, value]) => {
-                                if (typeof value === 'string') {
+                                if (value && typeof value === 'string') {
                                     return (
                                         <Labeled>
                                             <IdField source={'statusMap.' + key} />
                                         </Labeled>
                                     );
-                                } else if (Object.prototype.toString.call(value) === '[object Object]'){
+                                } else if (value && Object.prototype.toString.call(value) === '[object Object]'){
                                     return (
-                                         Object.entries(value).map(([subkey, subvalue]) => (
-                                             <Labeled>
+                                        Object.entries(value).map(([subkey, subvalue]) => (
+                                            <Labeled>
                                                 <IdField source={'statusMap.' + key + '.["' + subkey + '"]'} />
-                                             </Labeled>
-                                         ))
+                                            </Labeled>
+                                        ))
                                     );
-                                }else{
+                                } else {
                                      return ( <></> );
                                 }
                             })}

--- a/dev-console/src/idps/schemas.ts
+++ b/dev-console/src/idps/schemas.ts
@@ -265,22 +265,23 @@ export const uiSchemaOpenidfedIdp: UiSchema = {
     },
 };
 export const uiSchemaSpidIdp: UiSchema = {
-    'ui:layout': [12, 6, 6, 6, 6, 12, 6, 6, 6, 6, 12, 12, 12, 12, 12, 6, 6],
+    'ui:layout': [6, 6, 12, 12, 12, 4, 4, 4, 6, 6, 12, 12, 12, 6, 6, 12, 6, 6],
     'ui:order': [
-        'entityId',
         'signingKey',
         'signingCertificate',
-        'organizationDisplayName',
+        'metadataUrl',
+        'metadataXML',
+        'entityId',
         'organizationName',
+        'organizationDisplayName',
         'organizationUrl',
-        'contactPerson_EmailAddress',
-        'contactPerson_Type',
-        'contactPerson_IPACode',
-        'contactPerson_Public',
+        'contactPersonEmailAddress',
+        'contactPersonIPACode',
+        'spidAttributes',
         'idps',
         'idpMetadataUrl',
-        'spidAttributes',
         'useAssertionConsumerServiceUrl',
+        'attributeConsumingServiceIndex',
         'authnContext',
         'subAttributeName',
         'usernameAttributeName',
@@ -289,6 +290,9 @@ export const uiSchemaSpidIdp: UiSchema = {
         'ui:widget': 'textarea',
     },
     signingCertificate: {
+        'ui:widget': 'textarea',
+    },
+    metadataXML: {
         'ui:widget': 'textarea',
     },
     spidAttributes: {

--- a/src/main/java/it/smartcommunitylab/aac/base/model/AbstractStatusMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/base/model/AbstractStatusMap.java
@@ -29,6 +29,8 @@ import it.smartcommunitylab.aac.core.model.ConfigMap;
 import it.smartcommunitylab.aac.oidc.provider.OIDCIdentityProviderStatusMap;
 import it.smartcommunitylab.aac.repository.SchemaGeneratorFactory;
 import it.smartcommunitylab.aac.saml.provider.SamlIdentityProviderStatusMap;
+import it.smartcommunitylab.aac.spid.provider.SpidIdentityProviderStatusMap;
+
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +41,7 @@ import java.util.Map;
     {
         @Type(value = OIDCIdentityProviderStatusMap.class, name = OIDCIdentityProviderStatusMap.RESOURCE_TYPE),
         @Type(value = SamlIdentityProviderStatusMap.class, name = SamlIdentityProviderStatusMap.RESOURCE_TYPE),
+        @Type(value = SpidIdentityProviderStatusMap.class, name = SpidIdentityProviderStatusMap.RESOURCE_TYPE),
     }
 )
 public abstract class AbstractStatusMap implements ConfigMap, Serializable {

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidAuthenticationRequestContextConverter.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidAuthenticationRequestContextConverter.java
@@ -178,7 +178,7 @@ public class SpidAuthenticationRequestContextConverter
             auth.setAssertionConsumerServiceIndex(0);
         }
         
-        auth.setAttributeConsumingServiceIndex(0);
+        auth.setAttributeConsumingServiceIndex(providerConfig.getAttributeConsumingServiceIndex());
 
         //        Scoping scoping = new ScopingBuilder().buildObject();
         //        scoping.setProxyCount(0);

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataFilter.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataFilter.java
@@ -24,12 +24,7 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.springframework.core.convert.converter.Converter;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
-import org.springframework.security.saml2.provider.service.metadata.OpenSamlMetadataResolver;
-import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.web.DefaultRelyingPartyRegistrationResolver;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
@@ -37,6 +32,7 @@ import org.springframework.security.saml2.provider.service.web.Saml2MetadataFilt
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
+import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 /*
@@ -48,6 +44,8 @@ public class SpidMetadataFilter extends OncePerRequestFilter {
 
     public static final String DEFAULT_FILTER_URI = SpidIdentityAuthority.AUTHORITY_URL + "metadata/{registrationId}";
 
+    private final RequestMatcher requestMatcher;
+    private final ProviderConfigRepository<SpidIdentityProviderConfig> providerConfigRegistrationRepository;
     private final Saml2MetadataFilter samlMetadataFilter;
 
     public SpidMetadataFilter(
@@ -63,11 +61,13 @@ public class SpidMetadataFilter extends OncePerRequestFilter {
         RequestMatcher requestMatcher = new AntPathRequestMatcher(DEFAULT_FILTER_URI);
         SpidMetadataResolver metadataResolver = new SpidMetadataResolver(configRepository);
 
-        samlMetadataFilter = new Saml2MetadataFilter(registrationResolver, metadataResolver);
+        this.requestMatcher = requestMatcher;
+        this.providerConfigRegistrationRepository = configRepository;
 
-        samlMetadataFilter.setRequestMatcher(requestMatcher);
-        samlMetadataFilter.setBeanName("SamlMetadataFilter" + "." + SpidIdentityAuthority.AUTHORITY_URL);
-        samlMetadataFilter.setMetadataFilename("spid-{registrationId}-metadata.xml");
+        this.samlMetadataFilter = new Saml2MetadataFilter(registrationResolver, metadataResolver);
+        this.samlMetadataFilter.setRequestMatcher(requestMatcher);
+        this.samlMetadataFilter.setBeanName("SamlMetadataFilter" + "." + SpidIdentityAuthority.AUTHORITY_URL);
+        this.samlMetadataFilter.setMetadataFilename("spid-{registrationId}-metadata.xml");
     }
 
     @Nullable
@@ -78,6 +78,18 @@ public class SpidMetadataFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
         throws ServletException, IOException {
+        
+        String registrationId = requestMatcher.matcher(request).getVariables().get("registrationId");
+        // registrationId is base64UrlEncode({registrationId})
+        String providerId = SpidIdentityProviderConfig.decodeRegistrationId(registrationId);
+        SpidIdentityProviderConfig providerConfig = providerConfigRegistrationRepository.findByProviderId(providerId);
+        if (providerConfig == null 
+            || StringUtils.hasText(providerConfig.getConfigMap().getMetadataUrl())
+            || StringUtils.hasText(providerConfig.getConfigMap().getMetadataXML())) {
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+        }
+
         // delegate
         samlMetadataFilter.doFilter(request, response, filterChain);
     }

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataFilter.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataFilter.java
@@ -20,54 +20,56 @@ import it.smartcommunitylab.aac.core.provider.ProviderConfigRepository;
 import it.smartcommunitylab.aac.spid.SpidIdentityAuthority;
 import it.smartcommunitylab.aac.spid.provider.SpidIdentityProviderConfig;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.lang.Nullable;
+import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrationRepository;
 import org.springframework.security.saml2.provider.service.web.DefaultRelyingPartyRegistrationResolver;
 import org.springframework.security.saml2.provider.service.web.RelyingPartyRegistrationResolver;
-import org.springframework.security.saml2.provider.service.web.Saml2MetadataFilter;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.util.Assert;
-import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-/*
- * SpidMetadataFilter is a wrapper around Saml2MetadataFilter that defines a custom registration resolver
- * and custom metadata resolver to comply with SPID peculiarities.
- * In the context of metadata, registrationId is providerId.
- */
 public class SpidMetadataFilter extends OncePerRequestFilter {
 
     public static final String DEFAULT_FILTER_URI = SpidIdentityAuthority.AUTHORITY_URL + "metadata/{registrationId}";
+    public static final String DEFAULT_METADATA_FILE_NAME = "spid-{registrationId}-metadata.xml";
 
+    private final RelyingPartyRegistrationResolver relyingPartyRegistrationResolver;
+	private final SpidMetadataResolver metadataResolver;
     private final RequestMatcher requestMatcher;
-    private final ProviderConfigRepository<SpidIdentityProviderConfig> providerConfigRegistrationRepository;
-    private final Saml2MetadataFilter samlMetadataFilter;
+    private String metadataFilename = DEFAULT_METADATA_FILE_NAME;
 
     public SpidMetadataFilter(
         ProviderConfigRepository<SpidIdentityProviderConfig> configRepository,
         RelyingPartyRegistrationRepository relyingPartyRegistrationRepository
     ) {
+        this(configRepository, relyingPartyRegistrationRepository, DEFAULT_FILTER_URI);
+    }
+
+    public SpidMetadataFilter(
+        ProviderConfigRepository<SpidIdentityProviderConfig> configRepository,
+        RelyingPartyRegistrationRepository relyingPartyRegistrationRepository,
+        String filterProcessingUrl
+    ) {
         Assert.notNull(configRepository, "provider registration repository cannot be null");
         Assert.notNull(relyingPartyRegistrationRepository, "relyingPartyRegistrationRepository cannot be null");
-        RelyingPartyRegistrationResolver registrationResolver = new DefaultRelyingPartyRegistrationResolver(
+
+        this.relyingPartyRegistrationResolver = new DefaultRelyingPartyRegistrationResolver(
             relyingPartyRegistrationRepository
         );
-
-        RequestMatcher requestMatcher = new AntPathRequestMatcher(DEFAULT_FILTER_URI);
-        SpidMetadataResolver metadataResolver = new SpidMetadataResolver(configRepository);
-
-        this.requestMatcher = requestMatcher;
-        this.providerConfigRegistrationRepository = configRepository;
-
-        this.samlMetadataFilter = new Saml2MetadataFilter(registrationResolver, metadataResolver);
-        this.samlMetadataFilter.setRequestMatcher(requestMatcher);
-        this.samlMetadataFilter.setBeanName("SamlMetadataFilter" + "." + SpidIdentityAuthority.AUTHORITY_URL);
-        this.samlMetadataFilter.setMetadataFilename("spid-{registrationId}-metadata.xml");
+        this.metadataResolver = new SpidMetadataResolver(configRepository);
+        this.requestMatcher = new AntPathRequestMatcher(filterProcessingUrl);
     }
 
     @Nullable
@@ -77,20 +79,31 @@ public class SpidMetadataFilter extends OncePerRequestFilter {
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
-        throws ServletException, IOException {
-        
-        String registrationId = requestMatcher.matcher(request).getVariables().get("registrationId");
-        // registrationId is base64UrlEncode({registrationId})
-        String providerId = SpidIdentityProviderConfig.decodeRegistrationId(registrationId);
-        SpidIdentityProviderConfig providerConfig = providerConfigRegistrationRepository.findByProviderId(providerId);
-        if (providerConfig == null 
-            || StringUtils.hasText(providerConfig.getConfigMap().getMetadataUrl())
-            || StringUtils.hasText(providerConfig.getConfigMap().getMetadataXML())) {
-            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            throws ServletException, IOException {
+        RequestMatcher.MatchResult matcher = this.requestMatcher.matcher(request);
+		if (!matcher.isMatch()) {
+			filterChain.doFilter(request, response);
 			return;
-        }
-
-        // delegate
-        samlMetadataFilter.doFilter(request, response, filterChain);
+		}
+		String registrationId = matcher.getVariables().get("registrationId");
+		RelyingPartyRegistration relyingPartyRegistration = relyingPartyRegistrationResolver.resolve(request, registrationId);
+		if (relyingPartyRegistration == null) {
+			response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+			return;
+		}
+		String metadata = metadataResolver.resolve(relyingPartyRegistration);
+		writeMetadataToResponse(response, relyingPartyRegistration.getRegistrationId(), metadata);
     }
+
+    private void writeMetadataToResponse(HttpServletResponse response, String registrationId, String metadata) 
+            throws IOException {
+        response.setContentType(MediaType.APPLICATION_XML_VALUE);
+		String fileName = metadataFilename.replace("{registrationId}", registrationId);
+		String encodedFileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8.name());
+		String format = "attachment; filename=\"%s\"; filename*=UTF-8''%s";
+		response.setHeader(HttpHeaders.CONTENT_DISPOSITION, String.format(format, fileName, encodedFileName));
+		response.setContentLength(metadata.getBytes(StandardCharsets.UTF_8).length);
+		response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+		response.getWriter().write(metadata);
+	}
 }

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataResolver.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataResolver.java
@@ -18,7 +18,6 @@ package it.smartcommunitylab.aac.spid.auth;
 
 import it.smartcommunitylab.aac.core.provider.ProviderConfigRepository;
 import it.smartcommunitylab.aac.spid.provider.SpidIdentityProviderConfig;
-import it.smartcommunitylab.aac.spid.provider.SpidIdentityProviderConfigMap;
 import java.security.cert.CertificateEncodingException;
 import java.util.ArrayList;
 import java.util.Base64;
@@ -85,7 +84,6 @@ public class SpidMetadataResolver implements Saml2MetadataResolver {
     public static final String SPID_NAMESPACE_URI = "https://spid.gov.it/saml-extensions";
 
     public static final String SPID_NAMESPACE_PREFIX = "spid";
-    private static final String DEFAULT_SERVICE_NAME = "Set0";
     private static final char PATH_DELIMITER = '/';
 
     private final ProviderConfigRepository<SpidIdentityProviderConfig> configRepository;
@@ -257,25 +255,27 @@ public class SpidMetadataResolver implements Saml2MetadataResolver {
         assertionConsumerService.setIsDefault(true);
         spSsoDescriptor.getAssertionConsumerServices().add(assertionConsumerService);
 
-        // Add single attribute consuming service to <SPSSODescriptor>. The metadata exposes one and only
-        // one index set (Set0) associated to an attribute set configurable by the user.
-        AttributeConsumingService attributeConsumingService = attributeConsumingServiceBuilder.buildObject();
-        attributeConsumingService.setIndex(0);
-        attributeConsumingService.setIsDefault(true);
-
-        ServiceName defaultServiceName = serviceNameBuilder.buildObject();
-        defaultServiceName.setValue(DEFAULT_SERVICE_NAME);
-        defaultServiceName.setXMLLang("it");
-        attributeConsumingService.getNames().add(defaultServiceName);
+        // Add attribute consuming services to <SPSSODescriptor>.
         config
-            .getSpidAttributes()
-            .forEach(attr -> {
-                RequestedAttribute attribute = requestedAttributeBuilder.buildObject();
-                attribute.setName(attr.getValue());
-                attributeConsumingService.getRequestedAttributes().add(attribute);
-            });
+            .getAttributeConsumingServices()
+            .forEach(attrService -> {
+                AttributeConsumingService attributeConsumingService = attributeConsumingServiceBuilder.buildObject();
+                attributeConsumingService.setIndex(attrService.getIndex());
 
-        spSsoDescriptor.getAttributeConsumingServices().add(attributeConsumingService);
+                ServiceName serviceName = serviceNameBuilder.buildObject();
+                serviceName.setValue(attrService.getName());
+                serviceName.setXMLLang("it");
+                attributeConsumingService.getNames().add(serviceName);
+                attrService
+                    .getAttributes()
+                    .forEach(attr -> {
+                        RequestedAttribute attribute = requestedAttributeBuilder.buildObject();
+                        attribute.setName(attr.getValue());
+                        attributeConsumingService.getRequestedAttributes().add(attribute);
+                    });
+
+                spSsoDescriptor.getAttributeConsumingServices().add(attributeConsumingService);
+            });
 
         // Add single logout service to <SPSSODescriptor>
         // extract baseUrl
@@ -304,43 +304,41 @@ public class SpidMetadataResolver implements Saml2MetadataResolver {
     }
 
     private Organization buildOrganization(SpidIdentityProviderConfig config) {
-        SpidIdentityProviderConfigMap configMap = config.getConfigMap();
         Organization organization = organizationBuilder.buildObject();
 
         OrganizationName organizationName = organizationNameBuilder.buildObject();
         organizationName.setXMLLang("it");
-        organizationName.setValue(configMap.getOrganizationName());
+        organizationName.setValue(config.getOrganizationName());
         organization.getOrganizationNames().add(organizationName);
 
         OrganizationDisplayName organizationDisplayName = organizationDisplayNameBuilder.buildObject();
         organizationDisplayName.setXMLLang("it");
-        organizationDisplayName.setValue(configMap.getOrganizationDisplayName());
+        organizationDisplayName.setValue(config.getOrganizationDisplayName());
         organization.getDisplayNames().add(organizationDisplayName);
 
         OrganizationURL organizationUrl = organizationURLBuilder.buildObject();
         organizationUrl.setXMLLang("it");
-        organizationUrl.setURI(configMap.getOrganizationUrl());
+        organizationUrl.setURI(config.getOrganizationUrl());
         organization.getURLs().add(organizationUrl);
         return organization;
     }
 
     private ContactPerson buildContactPerson(SpidIdentityProviderConfig config) {
-        SpidIdentityProviderConfigMap configMap = config.getConfigMap();
         boolean isPublic = true; // private sp are currently not supported
 
         ContactPerson contactPerson = contactPersonBuilder.buildObject();
         contactPerson.setType(ContactPersonTypeEnumeration.OTHER);
 
         EmailAddress emailAddress = emailAddressBuilder.buildObject();
-        emailAddress.setURI(configMap.getContactPerson_EmailAddress());
+        emailAddress.setURI(config.getContactPersonEmailAddress());
         contactPerson.getEmailAddresses().add(emailAddress);
 
         Extensions contactExtension = extensionsBuilder.buildObject();
         List<XMLObject> contactExtensions = new ArrayList<>();
 
-        if (StringUtils.hasText(configMap.getContactPerson_IPACode()) && isPublic) {
+        if (StringUtils.hasText(config.getContactPersonIPACode()) && isPublic) {
             XSAny ipaCode = xsAnyBuilder.buildObject(SPID_NAMESPACE_URI, "IPACode", SPID_NAMESPACE_PREFIX);
-            ipaCode.setTextContent(configMap.getContactPerson_IPACode());
+            ipaCode.setTextContent(config.getContactPersonIPACode());
             contactExtensions.add(ipaCode);
         }
 

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataResolver.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidMetadataResolver.java
@@ -200,7 +200,7 @@ public class SpidMetadataResolver implements Saml2MetadataResolver {
             throw new Saml2Exception(e);
         }
         // add signature to element
-        return SerializeSupport.nodeToString(element);
+        return SerializeSupport.prettyPrintXML(element);
     }
 
     // build an the Metadata root element, which is a single Entity Descriptor, except for signature

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidProviderAssertionValidatorBuilder.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidProviderAssertionValidatorBuilder.java
@@ -1,13 +1,13 @@
 package it.smartcommunitylab.aac.spid.auth;
 
 import it.smartcommunitylab.aac.spid.model.SpidAttribute;
+import it.smartcommunitylab.aac.spid.model.SpidAttributeConsumingService;
 import it.smartcommunitylab.aac.spid.model.SpidAuthnContext;
 import it.smartcommunitylab.aac.spid.model.SpidError;
 import it.smartcommunitylab.aac.spid.service.SpidRequestParser;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import org.opensaml.saml.saml2.core.Assertion;
 import org.opensaml.saml.saml2.core.AuthnContextClassRef;
@@ -24,14 +24,14 @@ import org.springframework.util.StringUtils;
 
 public class SpidProviderAssertionValidatorBuilder {
 
-    private final Set<SpidAttribute> requestedAttributes;
+    private final Set<SpidAttributeConsumingService> attributeConsumingServices;
 
-    public SpidProviderAssertionValidatorBuilder(Set<SpidAttribute> requestedAttributes) {
-        this.requestedAttributes = requestedAttributes;
+    public SpidProviderAssertionValidatorBuilder(Set<SpidAttributeConsumingService> attributeConsumingServices) {
+        this.attributeConsumingServices = attributeConsumingServices;
     }
 
     public SpidProviderAssertionValidatorBuilder() {
-        this.requestedAttributes = new HashSet<>();
+        this.attributeConsumingServices = new HashSet<>();
     }
 
     public Converter<OpenSaml4AuthenticationProvider.AssertionToken, Saml2ResponseValidatorResult> build() {
@@ -127,7 +127,7 @@ public class SpidProviderAssertionValidatorBuilder {
                     )
                 );
             }
-            if (!areRequestedAttributesObtained(assertion)) {
+            if (!areRequestedAttributesObtained(initiatingRequest, assertion)) {
                 return result.concat(
                     new Saml2Error(Saml2ErrorCodes.INTERNAL_VALIDATION_ERROR, "missing requested attributes attribute")
                 );
@@ -255,11 +255,18 @@ public class SpidProviderAssertionValidatorBuilder {
      * the requested SPID attributes.
      * Note that *in general* a service provider might be configured with multiple attribute
      * sets and the SAML request actually specify which attribute sets, among the many, is
-     * actually request to the identity provider; but the current SPID implementation
-     * supports the definition of only *one* attribute set and that set is always requested.
+     * actually request to the identity provider.
      */
-    private boolean areRequestedAttributesObtained(Assertion assertion) {
+    private boolean areRequestedAttributesObtained(AuthnRequest initiatingRequest, Assertion assertion) {
         Set<SpidAttribute> obtainedAttributes = SpidProviderResponseValidatorBuilder.extractAttributes(assertion);
-        return obtainedAttributes != null && obtainedAttributes.containsAll(this.requestedAttributes);
+
+        Set<SpidAttribute> requestedAttributes = Collections.emptySet();
+        for (SpidAttributeConsumingService acs : this.attributeConsumingServices) {
+            if (acs.getAttributes() != null && acs.getIndex() == initiatingRequest.getAttributeConsumingServiceIndex()) {
+                requestedAttributes = acs.getAttributes();
+            }
+        }
+
+        return obtainedAttributes != null && obtainedAttributes.containsAll(requestedAttributes);
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidRelyingPartyRegistrationRepository.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidRelyingPartyRegistrationRepository.java
@@ -63,7 +63,7 @@ public class SpidRelyingPartyRegistrationRepository implements RelyingPartyRegis
                 return null;
             }
 
-            return providerConfig.getBareRelyingPartyRegistration();
+            return providerConfig.getRelyingPartyRegistration();
         }
         // registrationId is base64 url encode({providerId}|{entityLabel})
         // s[0], s[1] = providerId, entityLabel

--- a/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidRelyingPartyRegistrationRepository.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/auth/SpidRelyingPartyRegistrationRepository.java
@@ -63,7 +63,7 @@ public class SpidRelyingPartyRegistrationRepository implements RelyingPartyRegis
                 return null;
             }
 
-            return providerConfig.getRelyingPartyRegistration();
+            return providerConfig.getBareRelyingPartyRegistration();
         }
         // registrationId is base64 url encode({providerId}|{entityLabel})
         // s[0], s[1] = providerId, entityLabel
@@ -72,11 +72,6 @@ public class SpidRelyingPartyRegistrationRepository implements RelyingPartyRegis
             return null;
         }
 
-        return providerConfig
-            .getRelyingPartyRegistrations()
-            .stream()
-            .filter(reg -> reg.getRegistrationId().equals(registrationId))
-            .findAny()
-            .orElse(null);
+        return providerConfig.getRelyingPartyRegistration(s[1]);
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/spid/model/SpidAttributeConsumingService.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/model/SpidAttributeConsumingService.java
@@ -1,0 +1,43 @@
+package it.smartcommunitylab.aac.spid.model;
+
+import java.io.Serializable;
+import java.util.Set;
+
+public class SpidAttributeConsumingService implements Serializable {
+    
+    private Integer index;
+    private String name;
+    private Set<SpidAttribute> attributes;
+
+    public SpidAttributeConsumingService() {}
+
+    public SpidAttributeConsumingService(Integer index, String name, Set<SpidAttribute> attributes){
+        this.index = index;
+        this.name = name;
+        this.attributes = attributes;
+    }
+
+    public Integer getIndex() {
+        return this.index;
+    }
+
+    public void setIndex(Integer index) {
+        this.index = index;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+
+    public void setName(String name){
+        this.name = name;
+    }
+
+    public Set<SpidAttribute> getAttributes() {
+        return this.attributes;
+    }
+
+    public void setAttributes(Set<SpidAttribute> attributes) {
+        this.attributes = attributes;
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/spid/model/SpidMetadataConfiguration.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/model/SpidMetadataConfiguration.java
@@ -1,0 +1,94 @@
+package it.smartcommunitylab.aac.spid.model;
+
+import java.io.Serializable;
+import java.util.Set;
+
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+
+import it.smartcommunitylab.aac.SystemKeys;
+
+@Valid
+public class SpidMetadataConfiguration implements Serializable{
+    
+    private String entityId;
+
+    private Set<SpidAttributeConsumingService> attributeConsumingServices;
+
+    private String organizationName;
+    private String organizationDisplayName;
+    private String organizationUrl;
+
+    @Pattern(regexp = SystemKeys.EMAIL_PATTERN)
+    private String contactPersonEmailAddress;
+    @Pattern(regexp = "^[A-Za-z0-9_]*$")
+    private String contactPersonIPACode;
+
+    public SpidMetadataConfiguration() {}
+
+    public SpidMetadataConfiguration(String entityId, Set<SpidAttributeConsumingService> attributeConsumingServices, String organizationName, String organizationDisplayName, String organizationUrl, String contactPersonEmailAddress, String contactPersonIPACode) {
+        this.entityId = entityId;
+        this.attributeConsumingServices = attributeConsumingServices;
+        this.organizationName = organizationName;
+        this.organizationDisplayName = organizationDisplayName;
+        this.organizationUrl = organizationUrl;
+        this.contactPersonEmailAddress = contactPersonEmailAddress;
+        this.contactPersonIPACode = contactPersonIPACode;
+    }
+
+    public String getEntityId() {
+        return entityId;
+    }
+
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
+    }
+    
+    public Set<SpidAttributeConsumingService> getAttributeConsumingServices() {
+        return attributeConsumingServices;
+    }
+
+    public void setAttributeConsumingServices(Set<SpidAttributeConsumingService> attributeConsumingServices) {
+        this.attributeConsumingServices = attributeConsumingServices;
+    }
+
+    public String getOrganizationName() {
+        return organizationName;
+    }
+
+    public void setOrganizationName(String organizationName) {
+        this.organizationName = organizationName;
+    }
+
+    public String getOrganizationDisplayName() {
+        return organizationDisplayName;
+    }
+
+    public void setOrganizationDisplayName(String organizationDisplayName) {
+        this.organizationDisplayName = organizationDisplayName;
+    }
+
+    public String getOrganizationUrl() {
+        return organizationUrl;
+    }
+
+    public void setOrganizationUrl(String organizationUrl) {
+        this.organizationUrl = organizationUrl;
+    }
+
+    public String getContactPersonEmailAddress() {
+        return contactPersonEmailAddress;
+    }
+
+    public void setContactPersonEmailAddress(String contactPersonEmailAddress) {
+        this.contactPersonEmailAddress = contactPersonEmailAddress;
+    }
+
+    public String getContactPersonIPACode() {
+        return contactPersonIPACode;
+    }
+
+    public void setContactPersonIPACode(String contactPersonIPACode) {
+        this.contactPersonIPACode = contactPersonIPACode;
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidAuthenticationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidAuthenticationProvider.java
@@ -16,8 +16,6 @@
 
 package it.smartcommunitylab.aac.spid.provider;
 
-import static javax.swing.UIManager.put;
-
 import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.accounts.persistence.UserAccountService;
 import it.smartcommunitylab.aac.claims.ScriptExecutionService;
@@ -88,7 +86,7 @@ public class SpidAuthenticationProvider
 
         this.openSamlProvider = new OpenSaml4AuthenticationProvider();
         SpidProviderAssertionValidatorBuilder assertionValidatorBuilder = new SpidProviderAssertionValidatorBuilder(
-            config.getSpidAttributes()
+            config.getAttributeConsumingServices()
         );
         this.openSamlProvider.setAssertionValidator(assertionValidatorBuilder.build());
         SpidProviderResponseValidatorBuilder responseValidatorBuilder = new SpidProviderResponseValidatorBuilder();

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidFilterProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidFilterProvider.java
@@ -101,7 +101,8 @@ public class SpidFilterProvider implements FilterProvider, ApplicationEventPubli
 
         SpidMetadataFilter metadataFilter = new SpidMetadataFilter(
             providerConfigRepository,
-            relyingPartyRegistrationRepository
+            relyingPartyRegistrationRepository,
+            buildFilterUrl("metadata/{registrationId}")
         );
 
         filters.add(requestFilter);

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityConfigurationProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityConfigurationProvider.java
@@ -63,18 +63,20 @@ public class SpidIdentityConfigurationProvider
 
     @Override
     protected SpidIdentityProviderConfig buildConfig(ConfigurableIdentityProvider cp) {
-        SpidIdentityProviderConfig spidConfig = new SpidIdentityProviderConfig(
+        SpidIdentityProviderConfig p = new SpidIdentityProviderConfig(
             cp,
             getSettingsMap(cp.getSettings()),
             getConfigMap(cp.getConfiguration())
         );
         // TODO: how do I _know_ that local registry has been set by the time we invoke the buildConfig?
         //  Check architecture and relationship with IdentityAuthority
-        if (this.localRegistry != null) {
-            spidConfig.setIdentityProviders(this.localRegistry);
-            spidConfig.setBaseUrl(applicationProperties.getUrl());
+        p.setIdentityProviders(this.localRegistry);
+
+        if (applicationProperties != null) {
+            p.setBaseUrl(applicationProperties.getUrl());
         }
-        return spidConfig;
+
+        return p;
     }
 
     public void setLocalRegistry(Collection<SpidRegistration> localRegistry) {

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProvider.java
@@ -39,7 +39,6 @@ import javax.servlet.http.HttpServletRequest;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.provider.AuthorizationRequest;
-import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.util.StringUtils;
 
 public class SpidIdentityProvider
@@ -159,25 +158,13 @@ public class SpidIdentityProvider
         lp.setLoginUrl(getLoginUrl());
         
         List<SpidLoginProvider.SpidIdpButton> spidIdpsLogin = new LinkedList<>();
-        for (RelyingPartyRegistration reg : config.getRelyingPartyRegistrations()) {
-            String loginUrl = buildAuthenticationUrl(reg.getRegistrationId());
-
-            SpidRegistration spidReg = getConfig()
-                .getIdentityProviders()
-                .get(reg.getAssertingPartyDetails().getEntityId());
-
-            if (spidReg == null) {
-                // the provider is not preconfigured in the local registry
-                // create a default SpidRegistration
-                spidReg = new SpidRegistration();
-                spidReg.setEntityName(reg.getAssertingPartyDetails().getEntityId());
-                spidReg.setMetadataUrl(reg.getAssertingPartyDetails().getEntityId());
-                spidReg.setEntityLabel(reg.getAssertingPartyDetails().getEntityId());
-            }
+        for (SpidRegistration spidReg : config.getIdentityProviders()) {
+            String registrationId = SpidIdentityProviderConfig.encodeRegistrationId(config.evalRelyingPartyRegistrationId(spidReg.getEntityId()));
+            String loginUrl = buildAuthenticationUrl(registrationId);
 
             spidIdpsLogin.add(
                 new SpidLoginProvider.SpidIdpButton(
-                    reg.getAssertingPartyDetails().getEntityId(),
+                    spidReg.getEntityId(),
                     spidReg.getEntityName(),
                     spidReg.getMetadataUrl(),
                     spidReg.getEntityLabel(),

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProvider.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProvider.java
@@ -159,7 +159,7 @@ public class SpidIdentityProvider
         lp.setLoginUrl(getLoginUrl());
         
         List<SpidLoginProvider.SpidIdpButton> spidIdpsLogin = new LinkedList<>();
-        for (RelyingPartyRegistration reg : config.getUpstreamRelyingPartyRegistrations()) {
+        for (RelyingPartyRegistration reg : config.getRelyingPartyRegistrations()) {
             String loginUrl = buildAuthenticationUrl(reg.getRegistrationId());
 
             SpidRegistration spidReg = getConfig()
@@ -167,14 +167,12 @@ public class SpidIdentityProvider
                 .get(reg.getAssertingPartyDetails().getEntityId());
 
             if (spidReg == null) {
-                // log and skip faulty providers (for example, they might be offline)
-                // TODO: verifica se questo comportamento è ok
-                logger.error(
-                    "unable to associate the registration " +
-                    reg.getRegistrationId() +
-                    " with a SPID provider in the local registry"
-                );
-                continue;
+                // the provider is not preconfigured in the local registry
+                // create a default SpidRegistration
+                spidReg = new SpidRegistration();
+                spidReg.setEntityName(reg.getAssertingPartyDetails().getEntityId());
+                spidReg.setMetadataUrl(reg.getAssertingPartyDetails().getEntityId());
+                spidReg.setEntityLabel(reg.getAssertingPartyDetails().getEntityId());
             }
 
             spidIdpsLogin.add(

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -154,9 +154,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     public SpidIdentityProviderStatusMap getStatusMap() {
         if (statusMap == null) {
             statusMap = new SpidIdentityProviderStatusMap();
-            if (!StringUtils.hasText(configMap.getMetadataUrl()) && ! StringUtils.hasText(configMap.getMetadataXML())) {
-                statusMap.setMetadataUrl(getMetadataUrl());
-            }
+            statusMap.setMetadataUrl(getMetadataUrl());
             statusMap.setAssertionConsumerUrl(getAssertionConsumerUrl());
             statusMap.setMetadataConfiguration(getMetadataConfiguration());
         }

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -16,16 +16,7 @@
 
 package it.smartcommunitylab.aac.spid.provider;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import it.smartcommunitylab.aac.SystemKeys;
-import it.smartcommunitylab.aac.crypto.CertificateParser;
-import it.smartcommunitylab.aac.identity.base.AbstractIdentityProviderConfig;
-import it.smartcommunitylab.aac.identity.model.ConfigurableIdentityProvider;
-import it.smartcommunitylab.aac.identity.provider.IdentityProviderSettingsMap;
-import it.smartcommunitylab.aac.spid.SpidIdentityAuthority;
-import it.smartcommunitylab.aac.spid.model.SpidAttribute;
-import it.smartcommunitylab.aac.spid.model.SpidRegistration;
-import it.smartcommunitylab.aac.spid.model.SpidUserAttribute;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.ConnectException;
 import java.net.URI;
@@ -34,8 +25,35 @@ import java.nio.charset.StandardCharsets;
 import java.security.PrivateKey;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
+
+import javax.xml.namespace.NamespaceContext;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.web.client.RestTemplate;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathExpressionException;
+import javax.xml.xpath.XPathFactory;
+
 import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialSupport;
@@ -48,6 +66,24 @@ import org.springframework.security.saml2.provider.service.registration.Saml2Mes
 import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.crypto.CertificateParser;
+import it.smartcommunitylab.aac.identity.base.AbstractIdentityProviderConfig;
+import it.smartcommunitylab.aac.identity.model.ConfigurableIdentityProvider;
+import it.smartcommunitylab.aac.identity.provider.IdentityProviderSettingsMap;
+import it.smartcommunitylab.aac.spid.SpidIdentityAuthority;
+import it.smartcommunitylab.aac.spid.model.SpidAttribute;
+import it.smartcommunitylab.aac.spid.model.SpidAttributeConsumingService;
+import it.smartcommunitylab.aac.spid.model.SpidMetadataConfiguration;
+import it.smartcommunitylab.aac.spid.model.SpidRegistration;
+import it.smartcommunitylab.aac.spid.model.SpidUserAttribute;
 
 public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<SpidIdentityProviderConfigMap> {
 
@@ -55,17 +91,31 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     public static final String RESOURCE_TYPE =
         SystemKeys.RESOURCE_PROVIDER + SystemKeys.ID_SEPARATOR + SpidIdentityProviderConfigMap.RESOURCE_TYPE;
 
-    //    public static final String DEFAULT_METADATA_URL =
-    //        "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "metadata/{registrationId}";
-    //    public static final String DEFAULT_CONSUMER_URL =
-    //        "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/{registrationId}";
-    //    public static final String DEFAULT_LOGOUT_URL =
-    //        "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "slo/{registrationId}";
+    private static final String XPATH_EXPRESSION_ENTITY_ID = "/md:EntityDescriptor/@entityID";
+    private static final String XPATH_EXPRESSION_ORGANIZATION_NAME = "/md:EntityDescriptor/md:Organization/md:OrganizationName/text()";
+    private static final String XPATH_EXPRESSION_ORGANIZATION_DISPLAY_NAME = "/md:EntityDescriptor/md:Organization/md:OrganizationDisplayName/text()";
+    private static final String XPATH_EXPRESSION_ORGANIZATION_URL = "/md:EntityDescriptor/md:Organization/md:OrganizationURL/text()";
+    private static final String XPATH_EXPRESSION_CONTACT_PERSON_EMAIL_ADDRESS = "/md:EntityDescriptor/md:ContactPerson/md:EmailAddress/text()";
+    private static final String XPATH_EXPRESSION_CONTACT_PERSON_IPA_CODE = "/md:EntityDescriptor/md:ContactPerson/md:Extensions/spid:IPACode/text()";
+    private static final String XPATH_EXPRESSION_ATTRIBUTE_CONSUMING_SERVICES = "/md:EntityDescriptor//md:AttributeConsumingService";
+    private static final String XPATH_EXPRESSION_ACS_SERVICE_NAME = "md:ServiceName/text()";
+    private static final String XPATH_EXPRESSION_ACS_REQUESTED_ATTRIBUTE = "md:RequestedAttribute";
+    private static final String XPATH_EXPRESSION_SIGNING_CERTIFICATES = "/md:EntityDescriptor//md:KeyDescriptor[@use='signing']//ds:X509Certificate";
 
+    private static final int DEFAULT_TIMEOUT = 10000;
+    private static final int DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_INDEX = 0;
+    private static final String DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_NAME = "default";
+
+    private transient RelyingPartyRegistration bareRelyingPartyRegistration;
     private transient Set<RelyingPartyRegistration> relyingPartyRegistrations; // first time evaluated by the getter, then immutable
+    
     private Map<String, SpidRegistration> identityProviders; // local registry
+    private SpidMetadataConfiguration metadataConfiguration;
+
     private transient SpidIdentityProviderStatusMap statusMap;
     private String baseUrl;
+
+    private transient RestTemplate restTemplate;
 
     public SpidIdentityProviderConfig(String provider, String realm) {
         super(
@@ -75,8 +125,11 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
             new IdentityProviderSettingsMap(),
             new SpidIdentityProviderConfigMap()
         );
+        this.bareRelyingPartyRegistration = null;
         this.relyingPartyRegistrations = null;
         this.identityProviders = Collections.emptyMap();
+        this.metadataConfiguration = null;
+        this.restTemplate = null;
     }
 
     public SpidIdentityProviderConfig(
@@ -85,6 +138,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         SpidIdentityProviderConfigMap configs
     ) {
         super(cp, settings, configs);
+        loadMetadataConfiguration();
     }
 
     /**
@@ -93,6 +147,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
      * We need to implement this to enable deserialization of resources via
      * reflection
      */
+    @SuppressWarnings("unused")
     private SpidIdentityProviderConfig() {
         super();
     }
@@ -103,12 +158,18 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
 
     public SpidIdentityProviderStatusMap getStatusMap() {
         if (statusMap == null) {
-
             statusMap = new SpidIdentityProviderStatusMap();
-            statusMap.setMetadataUrl(getMetadataUrl());
-            statusMap.setAssertionConsumerUrls(getAssertionConsumerUrls());
+            if (!StringUtils.hasText(configMap.getMetadataUrl()) && ! StringUtils.hasText(configMap.getMetadataXML())) {
+                statusMap.setMetadataUrl(getMetadataUrl());
+            }
+            statusMap.setAssertionConsumerUrl(getAssertionConsumerUrl());
+            statusMap.setMetadataConfiguration(getMetadataConfiguration());
         }
         return statusMap;
+    }
+
+    public String metadataUrlTemplate() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "metadata/{registrationId}";
     }
 
     public String getMetadataUrl() {
@@ -119,27 +180,41 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return null;
     }
 
-    public String metadataUrlTemplate() {
-        return "{baseUrl}/auth/" + getAuthority() + "/metadata/{registrationId}";
+    public String assertionConsumerUrlTemplate() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/{registrationId}";
     }
 
-    public Map<String, String> getAssertionConsumerUrls(){
+    public String getAssertionConsumerUrl(){
         if (baseUrl != null) {
-            Map<String, String> assertionConsumerUrls = new HashMap<>();
-            for(RelyingPartyRegistration relyingPartyRegistration : getUpstreamRelyingPartyRegistrations()){
-                if(relyingPartyRegistration.getProviderDetails() != null) {
-                    assertionConsumerUrls.put(
-                            relyingPartyRegistration.getProviderDetails().getEntityId(),
-                            UriComponentsBuilder.fromUriString(assertionConsumerUrlTemplate()).buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", relyingPartyRegistration.getRegistrationId())).toUriString());
-                    }
-                }
-            return assertionConsumerUrls;
+            UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(assertionConsumerUrlTemplate());
+            return builder.buildAndExpand(Map.of("baseUrl", baseUrl, "registrationId", getMetadataRegistrationId())).toUriString();
         }
         return null;
     }
 
-    public String assertionConsumerUrlTemplate() {
-        return "{baseUrl}/auth/" + getAuthority() + "/authenticate/{registrationId}";
+    public Map<String, String> getMetadataConfiguration() {
+        Map<String, String> config = new LinkedHashMap<>();
+        config.put("entityId", getEntityId());
+        config.put("organizationName", getOrganizationName());
+        config.put("organizationDisplayName", getOrganizationDisplayName());
+        config.put("organizationUrl", getOrganizationUrl());
+        config.put("contactPersonEmailAddress", getContactPersonEmailAddress());
+        config.put("contactPersonIpaCode", getContactPersonIPACode());
+
+        getAttributeConsumingServices()
+            .stream()
+            .filter(acs -> acs.getIndex() == getAttributeConsumingServiceIndex())
+            .findFirst()
+            .ifPresent(acs -> config.put(
+                "attributeConsumingServiceIndex " + acs.getIndex(),
+                acs.getAttributes()
+                    .stream()
+                    .map(SpidAttribute::toString)
+                    .sorted()
+                    .collect(Collectors.joining(", "))
+            ));
+
+        return config;
     }
 
     /*
@@ -170,10 +245,28 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         }
     }
 
-    public String getEntityId() {
-        return configMap.getEntityId() != null ? configMap.getEntityId() : getMetadataUrl();
+    /*
+     * getBareRelyingPartyRegistration yields a single relying party registration 
+     * with registration id equal to the encoded providerId.
+     * This is required for cases where the registration does not require any asserting party details,
+     * such as SPID metadata.
+     */
+    @JsonIgnore
+    public RelyingPartyRegistration getBareRelyingPartyRegistration() {
+        if (bareRelyingPartyRegistration == null) {
+            try {
+                bareRelyingPartyRegistration = toBareRelyingPartyRegistration();
+            } catch (IOException | CertificateException e) {
+                throw new RuntimeException("error building registration: " + e.getMessage());
+            }
+        }
+        return bareRelyingPartyRegistration;
     }
 
+    /*
+     * getRelyingPartyRegistrations yields a set of relying party registrations;
+     * one for each configured upstream identity provider
+     */
     @JsonIgnore
     public Set<RelyingPartyRegistration> getRelyingPartyRegistrations() {
         if (relyingPartyRegistrations == null) {
@@ -186,17 +279,29 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return relyingPartyRegistrations;
     }
 
+    /*
+     * getRelyingPartyRegistration yields a single relying party registration 
+     * for the configured upstream identity provider associated to the input idpKey
+     */
     @JsonIgnore
-    public Set<RelyingPartyRegistration> getUpstreamRelyingPartyRegistrations() {
-        Set<RelyingPartyRegistration> regs = getRelyingPartyRegistrations();
-        return regs
-            .stream()
-            .filter(reg -> !reg.getRegistrationId().equals(getMetadataRegistrationId()))
-            .collect(Collectors.toSet());
+    public RelyingPartyRegistration getRelyingPartyRegistration(String idpKey) {
+        if (relyingPartyRegistrations == null) {
+            try {
+                String idpMetadataUrl = getAssertingPartyMetadataUrl(idpKey);
+                return toRelyingPartyRegistration(idpMetadataUrl);
+            } catch (IOException | CertificateException | URISyntaxException e) {
+                throw new RuntimeException("error building registration: " + e.getMessage());
+            }
+        }
+        String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(idpKey));
+        return relyingPartyRegistrations
+                .stream()
+                .filter(reg -> reg.getRegistrationId().equals(registrationId))
+                .findAny()
+                .orElse(null);
     }
 
-    // generate a registration (an RP/AP pair as defined by OpenSaml) for _each_
-    // configured upstream idps
+    // generate a registration (an RP/AP pair as defined by OpenSaml) for each configured upstream idps
     private Set<RelyingPartyRegistration> toRelyingPartyRegistrations() throws IOException, CertificateException {
         Set<RelyingPartyRegistration> registrations = new HashSet<>();
         try {
@@ -219,14 +324,209 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
             );
         }
 
-        // add a global registration for metadata
-        RelyingPartyRegistration metadataRegistration = RelyingPartyRegistration
-            .withRelyingPartyRegistration(registrations.iterator().next())
-            .registrationId(getMetadataRegistrationId())
-            .build();
-        registrations.add(metadataRegistration);
-
         return registrations;
+    }
+
+    // create a relying party registration with placeholder ap configuration.
+    private RelyingPartyRegistration toBareRelyingPartyRegistration() throws IOException, CertificateException {
+        RelyingPartyRegistration.Builder builder = RelyingPartyRegistration
+            .withRegistrationId(getMetadataRegistrationId())
+            .entityId(getEntityId())
+            .assertionConsumerServiceLocation(getConsumerUrl())
+            .assertionConsumerServiceBinding(Saml2MessageBinding.POST)
+            .singleLogoutServiceLocation(getLogoutUrl());
+        
+        builder.assertingPartyDetails(party -> 
+            party
+                .entityId("http://placeholder.entity.id")
+                .singleSignOnServiceLocation("http://placeholder.sso.location")
+        );
+
+        String signingKey = configMap.getSigningKey();
+        String signingCertificate = configMap.getSigningCertificate();
+        if (StringUtils.hasText(signingKey) && StringUtils.hasText(signingCertificate)) {
+            // only RSA keys are supported
+            Saml2X509Credential credential = CertificateParser.genCredentials(
+                signingKey,
+                signingCertificate,
+                Saml2X509Credential.Saml2X509CredentialType.SIGNING,
+                Saml2X509Credential.Saml2X509CredentialType.DECRYPTION
+            );
+            builder.signingX509Credentials(c -> c.add(credential));
+        }
+
+        return builder.build();
+    }
+
+    // create a relying party registration for an upstream idp; only ap autoconfiguration is supported,
+    // hence function parameters require an idp metadata url
+    private RelyingPartyRegistration toRelyingPartyRegistration(String idpMetadataUrl) throws IOException, CertificateException, URISyntaxException {
+        // start from ap autoconfiguration ...
+        String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(idpMetadataUrl)));
+        RelyingPartyRegistration.Builder builder = RelyingPartyRegistrations
+            .fromMetadataLocation(idpMetadataUrl)
+            .registrationId(registrationId);
+
+        // ... then expand with rp configuration (i.e. ourself)
+        builder
+            .entityId(getEntityId())
+            .assertionConsumerServiceLocation(getConsumerUrl())
+            .assertionConsumerServiceBinding(Saml2MessageBinding.POST)
+            .singleLogoutServiceLocation(getLogoutUrl());
+
+        String signingKey = configMap.getSigningKey();
+        String signingCertificate = configMap.getSigningCertificate();
+        if (StringUtils.hasText(signingKey) && StringUtils.hasText(signingCertificate)) {
+            // only RSA keys are supported
+            Saml2X509Credential credential = CertificateParser.genCredentials(
+                signingKey,
+                signingCertificate,
+                Saml2X509Credential.Saml2X509CredentialType.SIGNING,
+                Saml2X509Credential.Saml2X509CredentialType.DECRYPTION
+            );
+            builder.signingX509Credentials(c -> c.add(credential));
+        }
+
+        return builder.build();
+    }
+
+    // yield a unique key per upstream metadata (url)
+    // the key is fetched from configuration file (is present), otherwise host is used
+    // the function might throws an exception if the provided the metadata url is not
+    // a valid uri
+    public String evalIdpKeyIdentifier(String idpMetadataUrl) throws URISyntaxException {
+        Optional<SpidRegistration> reg =
+            this.identityProviders.values().stream().filter(r -> r.getMetadataUrl().equals(idpMetadataUrl)).findFirst();
+        if (reg.isPresent()) {
+            return reg.get().getEntityId();
+        }
+        return new URI(idpMetadataUrl).getHost();
+    }
+
+    // obtain an allegedly unique identifier from an idp key; this identifier can be used
+    // to identify a relying party registration
+    public String evalRelyingPartyRegistrationId(String idpKeyIdentifier) {
+        // NOTE: this function is 'inverted' by getProviderId(..)
+        return getProvider() + "|" + idpKeyIdentifier;
+    }
+
+    public String getConsumerUrl() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
+    }
+
+    public String getLogoutUrl() {
+        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
+    }
+
+    private String getMetadataRegistrationId() {
+        return encodeRegistrationId(getProvider());
+    }
+
+    public static String encodeRegistrationId(String regId) {
+        return Base64.getUrlEncoder().encodeToString(regId.getBytes());
+    }
+
+    public static String decodeRegistrationId(String encodedRegId) {
+        return new String(Base64.getUrlDecoder().decode(encodedRegId), StandardCharsets.UTF_8);
+    }
+
+    @JsonIgnore
+    public List<Credential> getRelyingPartySigningCredentials() {
+        List<Credential> credentials = new ArrayList<>();
+        RelyingPartyRegistration rp = getBareRelyingPartyRegistration();
+        if (rp == null) {
+            return credentials;
+        }
+        for (Saml2X509Credential x509Credential : rp.getSigningX509Credentials()) {
+            X509Certificate certificate = x509Credential.getCertificate();
+            PrivateKey privateKey = x509Credential.getPrivateKey();
+            BasicCredential credential = CredentialSupport.getSimpleCredential(certificate, privateKey);
+            credential.setEntityId(rp.getEntityId());
+            credential.setUsageType(UsageType.SIGNING);
+            credentials.add(credential);
+        }
+        return credentials;
+    }
+
+    // additional properties not supported by stock model
+    public Boolean getRelyingPartyRegistrationIsForceAuthn() {
+        // According to specs, ForceAuthn cannot be chosen for SpidL2 or SpidL3
+
+        // return always true due to check in spid validator
+        return true;
+    }
+
+    public String getEntityId() {
+        return metadataConfiguration.getEntityId() != null
+            ? metadataConfiguration.getEntityId()
+            : getMetadataUrl();
+    }
+
+    public Set<SpidAttributeConsumingService> getAttributeConsumingServices() {
+        return metadataConfiguration.getAttributeConsumingServices() != null
+            ? metadataConfiguration.getAttributeConsumingServices()
+            : Collections.emptySet();
+    }
+
+    public String getOrganizationName() {
+        return metadataConfiguration.getOrganizationName();
+    }
+
+    public String getOrganizationDisplayName() {
+        return metadataConfiguration.getOrganizationDisplayName();
+    }
+
+    public String getOrganizationUrl() {
+        return metadataConfiguration.getOrganizationUrl();
+    }
+
+    public String getContactPersonEmailAddress() {
+        return metadataConfiguration.getContactPersonEmailAddress();
+    }
+
+    public String getContactPersonIPACode() {
+        return metadataConfiguration.getContactPersonIPACode();
+    }
+
+    public Boolean getUseAssertionConsumerServiceUrl() {
+        return configMap.getUseAssertionConsumerServiceUrl() != null
+            && configMap.getUseAssertionConsumerServiceUrl();
+    }
+
+    public Integer getAttributeConsumingServiceIndex() {
+        return configMap.getAttributeConsumingServiceIndex() != null
+            ? configMap.getAttributeConsumingServiceIndex()
+            : DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_INDEX;
+    }
+
+    public Set<String> getRelyingPartyRegistrationAuthnContextClassRefs() {
+        return configMap.getAuthnContext() == null
+            ? Collections.emptySet()
+            : Collections.singleton(configMap.getAuthnContext().getValue());
+    }
+
+    public SpidUserAttribute getSubAttributeName() {
+        return configMap.getSubAttributeName();
+    }
+
+    public SpidUserAttribute getUsernameAttributeName() {
+        return configMap.getUsernameAttributeName();
+    }
+
+    public Set<String> getRelyingPartyRegistrationIds() {
+        Set<String> idpMetadataUrls = getAssertingPartyMetadataUrls();
+        Set<String> ids = idpMetadataUrls
+            .stream()
+            .map(u -> {
+                try {
+                    return encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(u)));
+                } catch (URISyntaxException e) {
+                    throw new IllegalArgumentException("invalid metadata uri " + e.getMessage());
+                }
+            })
+            .collect(Collectors.toSet());
+        ids.add(getMetadataRegistrationId());
+        return ids;
     }
 
     // returns the list of metadata urls of upstream idps
@@ -261,166 +561,227 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return idpMetadataUrls;
     }
 
-    // yield a unique key per upstream metadata (url)
-    // the key is fetched from configuration file (is present), otherwise host is used
-    // the function might throws an exception if the provided the metadata url is not
-    // a valid uri
-    public String evalIdpKeyIdentifier(String idpMetadataUrl) throws URISyntaxException {
-        Optional<SpidRegistration> reg =
-            this.identityProviders.values().stream().filter(r -> r.getMetadataUrl().equals(idpMetadataUrl)).findFirst();
-        if (reg.isPresent()) {
-            //            return reg.get().getEntityLabel();
-            return reg.get().getEntityId();
+    private String getAssertingPartyMetadataUrl(String idpKey) {
+        // idp urls must be defined by either in configMap or application config (and passed to this.idps)
+        if (StringUtils.hasText(configMap.getIdpMetadataUrl())) {
+            // single idp via url
+            return configMap.getIdpMetadataUrl();
         }
-        // TODO: rimozione fallback strategy?
-        return new URI(idpMetadataUrl).getHost();
+        return identityProviders.get(idpKey).getMetadataUrl();
     }
 
-    // obtain an allegedly unique identifier from an idp key; this identifier can be used
-    // to identify a relying party registration
-    public String evalRelyingPartyRegistrationId(String idpKeyIdentifier) {
-        // NOTE: this function is 'inverted' by getProviderId(..)
-        return getProvider() + "|" + idpKeyIdentifier;
-    }
-
-    public String getConsumerUrl() {
-        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "sso/" + getMetadataRegistrationId();
-    }
-
-    public String getLogoutUrl() {
-        return "{baseUrl}" + SpidIdentityAuthority.AUTHORITY_URL + "slo/" + getMetadataRegistrationId();
-    }
-
-    // create a relying party registration for an upstream idp; only ap autoconfiguration
-    // is supported, hence function parameters require an idp metadata url
-    private RelyingPartyRegistration toRelyingPartyRegistration(String idpMetadataUrl)
-        throws IOException, CertificateException, URISyntaxException {
-        // start from ap autoconfiguration ...
-        String key = evalIdpKeyIdentifier(idpMetadataUrl);
-        String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(key));
-        RelyingPartyRegistration.Builder builder = RelyingPartyRegistrations
-            .fromMetadataLocation(idpMetadataUrl)
-            .registrationId(registrationId);
-
-        // ... then expand with rp configuration (i.e. ourself)
-        builder
-            .entityId(getEntityId())
-            .assertionConsumerServiceLocation(getConsumerUrl())
-            .assertionConsumerServiceBinding(Saml2MessageBinding.POST)
-            .singleLogoutServiceLocation(getLogoutUrl());
-
-        String signingKey = configMap.getSigningKey();
-        String signingCertificate = configMap.getSigningCertificate();
-        if (StringUtils.hasText(signingKey) && StringUtils.hasText(signingCertificate)) {
-            // only RSA keys are supported
-            Saml2X509Credential credential = CertificateParser.genCredentials(
-                signingKey,
-                signingCertificate,
-                Saml2X509Credential.Saml2X509CredentialType.SIGNING,
-                Saml2X509Credential.Saml2X509CredentialType.DECRYPTION
+    private void loadMetadataConfiguration() {
+        if (StringUtils.hasText(configMap.getMetadataUrl())) {
+            try {
+                this.metadataConfiguration = getMetadataConfigurationFromUrl(configMap.getMetadataUrl());
+            } catch (IOException e) {
+                throw new IllegalArgumentException("failed to download metadata from URL: " + e.getMessage(), e);
+            }
+        } else if (StringUtils.hasText(configMap.getMetadataXML())) {
+            this.metadataConfiguration = getMetadataConfigurationFromXML(configMap.getMetadataXML());
+        } else {
+            Set<SpidAttributeConsumingService> attributeConsumingServices = new HashSet<>();
+            if (configMap.getSpidAttributes() != null) {
+                attributeConsumingServices.add(new SpidAttributeConsumingService(
+                    DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_INDEX,
+                    DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_NAME,
+                    configMap.getSpidAttributes()
+                ));
+            }
+            this.metadataConfiguration = new SpidMetadataConfiguration(
+                configMap.getEntityId(),
+                attributeConsumingServices,
+                configMap.getOrganizationName(),
+                configMap.getOrganizationDisplayName(),
+                configMap.getOrganizationUrl(),
+                configMap.getContactPersonEmailAddress(),
+                configMap.getContactPersonIPACode()
             );
-            builder.signingX509Credentials(c -> c.add(credential));
         }
 
-        return builder.build();
-    }
-
-    @JsonIgnore
-    public List<Credential> getRelyingPartySigningCredentials() {
-        List<Credential> credentials = new ArrayList<>();
-        RelyingPartyRegistration rp = getRelyingPartyRegistrations().stream().findFirst().orElse(null);
-        if (rp == null) {
-            return credentials;
+        if (this.metadataConfiguration == null) {
+            throw new IllegalArgumentException("empty metadata configuration");
         }
-        for (Saml2X509Credential x509Credential : rp.getSigningX509Credentials()) {
-            X509Certificate certificate = x509Credential.getCertificate();
-            PrivateKey privateKey = x509Credential.getPrivateKey();
-            BasicCredential credential = CredentialSupport.getSimpleCredential(certificate, privateKey);
-            credential.setEntityId(rp.getEntityId());
-            credential.setUsageType(UsageType.SIGNING);
-            credentials.add(credential);
+    }
+
+    private SpidMetadataConfiguration getMetadataConfigurationFromUrl(String url) throws IOException {
+        if (!StringUtils.hasText(url)) {
+            throw new IllegalArgumentException("metadata url is blank");
         }
-        return credentials;
+        ResponseEntity<String> response = getRestTemplate().exchange(url, HttpMethod.GET, null, String.class);
+        if (response == null || response.getStatusCode() == null) {
+            throw new IOException("failed to fetch metadata, empty response");
+        }
+        if (!response.getStatusCode().is2xxSuccessful()) {
+            throw new IOException("failed to fetch metadata, status: " + response.getStatusCode());
+        }
+        String xml = response.getBody();
+        if (!StringUtils.hasText(xml)) {
+            throw new IOException("empty metadata response body");
+        }
+        return getMetadataConfigurationFromXML(xml);
     }
 
-    // additional properties not supported by stock model
-    public Boolean getRelyingPartyRegistrationIsForceAuthn() {
-        // According to specs, ForceAuthn cannot be chosen for SpidL2 or SpidL3
+    private SpidMetadataConfiguration getMetadataConfigurationFromXML(String xml) {
+        SpidMetadataConfiguration metadataConfiguration = new SpidMetadataConfiguration();
+        try {
+            Document doc = parseMetadataXml(xml);
+            XPath xpath = newXPath();
+            String entityId = (String) xpath.evaluate(XPATH_EXPRESSION_ENTITY_ID, doc, XPathConstants.STRING);
+            String organizationName = (String) xpath.evaluate(XPATH_EXPRESSION_ORGANIZATION_NAME, doc, XPathConstants.STRING);
+            String organizationDisplayName = (String) xpath.evaluate(XPATH_EXPRESSION_ORGANIZATION_DISPLAY_NAME, doc, XPathConstants.STRING);
+            String organizationURL = (String) xpath.evaluate(XPATH_EXPRESSION_ORGANIZATION_URL, doc, XPathConstants.STRING);
+            String contactPersonEmailAddress = (String) xpath.evaluate(XPATH_EXPRESSION_CONTACT_PERSON_EMAIL_ADDRESS, doc, XPathConstants.STRING);
+            String contactPersonIPACode = (String) xpath.evaluate(XPATH_EXPRESSION_CONTACT_PERSON_IPA_CODE, doc, XPathConstants.STRING);
+            
+            Set<SpidAttributeConsumingService> attributeConsumingServices = Collections.emptySet();
+            NodeList acsList = (NodeList) xpath.evaluate(XPATH_EXPRESSION_ATTRIBUTE_CONSUMING_SERVICES, doc, XPathConstants.NODESET);
+            if (acsList != null && acsList.getLength() > 0) {
+                attributeConsumingServices = parseAttributeConsumingServicesFromMetadata(acsList, xpath);
+            }
 
-        // return always true due to check in spid validator
-        return true;
+            metadataConfiguration.setEntityId(entityId);
+            metadataConfiguration.setAttributeConsumingServices(attributeConsumingServices);
+            metadataConfiguration.setOrganizationName(organizationName);
+            metadataConfiguration.setOrganizationDisplayName(organizationDisplayName);
+            metadataConfiguration.setOrganizationUrl(organizationURL);
+            metadataConfiguration.setContactPersonEmailAddress(contactPersonEmailAddress);
+            metadataConfiguration.setContactPersonIPACode(contactPersonIPACode);
+
+            // verify metadata X509Certificate against configured signingCertificate
+            verifyX509Certificate(doc, xpath);
+            
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid metadata XML: " + e.getMessage(), e);
+        }
+
+        return metadataConfiguration;
     }
 
-    public Set<SpidAttribute> getSpidAttributes() {
-        return configMap.getSpidAttributes() == null ? Collections.emptySet() : configMap.getSpidAttributes();
-    }
+    private Set<SpidAttributeConsumingService> parseAttributeConsumingServicesFromMetadata(NodeList acsList, XPath xpath) throws XPathExpressionException {
+        Set<SpidAttributeConsumingService> attributeConsumingServices = new HashSet<>();
 
-    public Boolean getUseAssertionConsumerServiceUrl() {
-        return configMap.getUseAssertionConsumerServiceUrl() != null
-            ? configMap.getUseAssertionConsumerServiceUrl()
-            : Boolean.FALSE;
-    }
+        for (int i = 0; i < acsList.getLength(); i++) {
+            Element acs = (Element) acsList.item(i);
+            
+            String index = acs.getAttribute("index");
+            String serviceName = (String) xpath.evaluate(XPATH_EXPRESSION_ACS_SERVICE_NAME, acs, XPathConstants.STRING);
 
-    public Set<String> getRelyingPartyRegistrationAuthnContextClassRefs() {
-        return configMap.getAuthnContext() == null
-            ? Collections.emptySet()
-            : Collections.singleton(configMap.getAuthnContext().getValue());
-    }
+            Set<SpidAttribute> attributes = new HashSet<>();
+            NodeList attrList = (NodeList) xpath.evaluate(XPATH_EXPRESSION_ACS_REQUESTED_ATTRIBUTE, acs, XPathConstants.NODESET);
+            for (int j = 0; j < attrList.getLength(); j++) {
+                Element attr = (Element) attrList.item(j);
 
-    public SpidUserAttribute getSubAttributeName() {
-        return configMap.getSubAttributeName();
-    }
-
-    public SpidUserAttribute getUsernameAttributeName() {
-        return configMap.getUsernameAttributeName();
-    }
-
-    public Set<String> getRelyingPartyRegistrationIds() {
-        Set<String> idpMetadataUrls = getAssertingPartyMetadataUrls();
-        Set<String> ids = idpMetadataUrls
-            .stream()
-            .map(u -> {
-                try {
-                    return encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(u)));
-                } catch (URISyntaxException e) {
-                    throw new IllegalArgumentException("invalid metadata uri " + e.getMessage());
+                String name = attr.getAttribute("Name");
+                SpidAttribute attribute = SpidAttribute.parse(name);
+                if (attribute != null) {
+                    attributes.add(attribute);
                 }
-            })
-            .collect(Collectors.toSet());
-        ids.add(getMetadataRegistrationId());
-        return ids;
+            }
+
+            SpidAttributeConsumingService attributeConsumingService = new SpidAttributeConsumingService(Integer.parseInt(index), serviceName, attributes);
+            attributeConsumingServices.add(attributeConsumingService);
+        }
+
+        Integer index = getAttributeConsumingServiceIndex();
+        Boolean indexExists = attributeConsumingServices.stream().anyMatch(acs -> index.equals(acs.getIndex()));
+        if (!indexExists) {
+            throw new IllegalArgumentException("configured attribute consuming service index not present in metadata attribute consuming services");
+        }
+
+        return attributeConsumingServices;
     }
 
-    private String getMetadataRegistrationId() {
-        return encodeRegistrationId(getProvider());
+    private void verifyX509Certificate(Document doc, XPath xpath) throws XPathExpressionException {
+        NodeList metaCertList = (NodeList) xpath.evaluate(XPATH_EXPRESSION_SIGNING_CERTIFICATES, doc, XPathConstants.NODESET);
+        if (metaCertList == null || metaCertList.getLength() == 0) {
+            throw new IllegalArgumentException("empty signing certificate in metadata");
+        }
+
+        Set<String> metaCertNormalizedList = new HashSet<>();
+        for (int i = 0; i < metaCertList.getLength(); i++) {
+            String metaCert = metaCertList.item(i).getTextContent();
+            String metaCertNormalized = stripPem(metaCert);
+            if (StringUtils.hasText(metaCertNormalized)) {
+                metaCertNormalizedList.add(metaCertNormalized);
+            }
+        }
+        if (metaCertNormalizedList.isEmpty()) {
+            throw new IllegalArgumentException("no valid signing certificates found in metadata");
+        }
+        
+        String confCert = configMap.getSigningCertificate();
+        String confCertNormalized = stripPem(confCert);
+        if (!metaCertNormalizedList.contains(confCertNormalized)) {
+            throw new IllegalArgumentException("configured signingCertificate not present in metadata signing X509Certificate");
+        }
     }
 
-    /*
-     * getRelyingPartyRegistration yields a _single_ relying party registration with id equals to providerId.
-     * This is required for cases where the registration does not require any asserting party details,
-     * such as SPID metadata.
-     */
-    @JsonIgnore
-    public RelyingPartyRegistration getRelyingPartyRegistration() {
-        return getRelyingPartyRegistrations()
-            .stream()
-            .findAny()
-            .map(r ->
-                RelyingPartyRegistration
-                    .withRelyingPartyRegistration(r)
-                    .registrationId(getMetadataRegistrationId())
-                    .build()
-            )
-            .orElse(null);
+    private Document parseMetadataXml(String xml) throws ParserConfigurationException, IOException, SAXException {
+        if (!StringUtils.hasText(xml)) {
+            throw new IllegalArgumentException("no metadata XML configured");
+        }
+        DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+        dbf.setNamespaceAware(true);
+        DocumentBuilder db = dbf.newDocumentBuilder();
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))) {
+            return db.parse(bais);
+        }
     }
 
-    public static String encodeRegistrationId(String regId) {
-        //        return URLEncoder.encode(regId, StandardCharsets.UTF_8);
-        return Base64.getUrlEncoder().encodeToString(regId.getBytes());
+    private XPath newXPath() {
+        XPathFactory xpf = XPathFactory.newInstance();
+        XPath xpath = xpf.newXPath();
+        xpath.setNamespaceContext(new NamespaceContext() {
+            @Override
+            public String getNamespaceURI(String prefix) {
+                switch (prefix) {
+                    case "md":
+                        return "urn:oasis:names:tc:SAML:2.0:metadata";
+                    case "ds":
+                        return "http://www.w3.org/2000/09/xmldsig#";
+                    case "spid":
+                        return "https://spid.gov.it/saml-extensions";
+                    case "xml":
+                        return "http://www.w3.org/XML/1998/namespace";
+                    default:
+                        return javax.xml.XMLConstants.NULL_NS_URI;
+                }
+            }
+
+            @Override
+            public String getPrefix(String namespaceURI) {
+                return null;
+            }
+
+            @Override
+            public Iterator<String> getPrefixes(String namespaceURI) {
+                return null;
+            }
+        });
+        return xpath;
     }
 
-    public static String decodeRegistrationId(String encodedRegId) {
-        //        return URLDecoder.decode(encodedRegId, StandardCharsets.UTF_8);
-        return new String(Base64.getUrlDecoder().decode(encodedRegId), StandardCharsets.UTF_8);
+    private String stripPem(String cert) {
+        if (cert == null) return null;
+        return cert
+            .replaceAll("-----BEGIN CERTIFICATE-----", "")
+            .replaceAll("-----END CERTIFICATE-----", "")
+            .replaceAll("\\s+", "");
+    }
+
+    private RestTemplate getRestTemplate() {
+        if (restTemplate == null) {
+            RequestConfig rconfig = RequestConfig
+                .custom()
+                .setConnectTimeout(DEFAULT_TIMEOUT)
+                .setConnectionRequestTimeout(DEFAULT_TIMEOUT)
+                .setSocketTimeout(DEFAULT_TIMEOUT)
+                .build();
+            CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(rconfig).build();
+            HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory(client);
+            restTemplate = new RestTemplate(clientHttpRequestFactory);
+        }
+        return restTemplate;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfig.java
@@ -18,7 +18,6 @@ package it.smartcommunitylab.aac.spid.provider;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
@@ -34,7 +33,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -58,7 +56,6 @@ import org.opensaml.security.credential.BasicCredential;
 import org.opensaml.security.credential.Credential;
 import org.opensaml.security.credential.CredentialSupport;
 import org.opensaml.security.credential.UsageType;
-import org.springframework.security.saml2.Saml2Exception;
 import org.springframework.security.saml2.core.Saml2X509Credential;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistration;
 import org.springframework.security.saml2.provider.service.registration.RelyingPartyRegistrations;
@@ -106,10 +103,9 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     private static final int DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_INDEX = 0;
     private static final String DEFAULT_ATTRIBUTE_CONSUMING_SERVICE_NAME = "default";
 
-    private transient RelyingPartyRegistration bareRelyingPartyRegistration;
-    private transient Set<RelyingPartyRegistration> relyingPartyRegistrations; // first time evaluated by the getter, then immutable
+    private transient Set<RelyingPartyRegistration> relyingPartyRegistrations;
     
-    private Map<String, SpidRegistration> identityProviders; // local registry
+    private Set<SpidRegistration> identityProviders;
     private SpidMetadataConfiguration metadataConfiguration;
 
     private transient SpidIdentityProviderStatusMap statusMap;
@@ -125,9 +121,8 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
             new IdentityProviderSettingsMap(),
             new SpidIdentityProviderConfigMap()
         );
-        this.bareRelyingPartyRegistration = null;
         this.relyingPartyRegistrations = null;
-        this.identityProviders = Collections.emptyMap();
+        this.identityProviders = Collections.emptySet();
         this.metadataConfiguration = null;
         this.restTemplate = null;
     }
@@ -234,49 +229,91 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
         return kp[0];
     }
 
-    public Map<String, SpidRegistration> getIdentityProviders() {
+    public Set<SpidRegistration> getIdentityProviders() {
         return identityProviders;
     }
 
-    public void setIdentityProviders(Collection<SpidRegistration> idpRegs) {
-        if (idpRegs != null) {
-            this.identityProviders =
-                idpRegs.stream().collect(Collectors.toMap(SpidRegistration::getEntityId, reg -> reg));
+    public void setIdentityProviders(Collection<SpidRegistration> localIdpRegistry) {
+        Set<SpidRegistration> identityProviders = new HashSet<>();
+
+        // identity providers must be defined either in the configMap via url or in the application configuration (local registry)
+        if (StringUtils.hasText(configMap.getIdpMetadataUrl())) {
+            // single idp via url
+            SpidRegistration reg = null;
+
+            if (localIdpRegistry != null) {
+                reg = localIdpRegistry
+                    .stream()
+                    .filter(idp -> idp.getMetadataUrl().equals(configMap.getIdpMetadataUrl()))
+                    .findFirst().orElse(null);
+            } 
+            if (reg == null) {
+                try {
+                    // build its relying party registration and create a default SpidRegistration
+                    RelyingPartyRegistration apReg = toRelyingPartyRegistration(configMap.getIdpMetadataUrl(), configMap.getIdpMetadataUrl());
+                    String idpEntityId = apReg.getAssertingPartyDetails().getEntityId();
+
+                    reg = new SpidRegistration();
+                    reg.setEntityId(idpEntityId);
+                    reg.setEntityName(idpEntityId);
+                    reg.setMetadataUrl(configMap.getIdpMetadataUrl());
+                    reg.setEntityLabel(idpEntityId);
+                } catch (IOException | CertificateException e) {
+				    // skip that registration if that idp is offline
+			    }
+            }
+            if (reg != null) {
+                identityProviders.add(reg);
+            }
+        } else if (localIdpRegistry != null) {
+            // multiple idps via local registry
+            // if config map defined some specific idps, pick those, otherwise pick all
+            if (configMap.getIdps() != null && !configMap.getIdps().isEmpty()) {
+                localIdpRegistry.stream()
+                    .filter(idp -> configMap.getIdps().contains(idp.getEntityId()))
+                    .forEach(idp -> identityProviders.add(idp));
+            } else {
+                identityProviders.addAll(localIdpRegistry);
+            }
         }
+
+        if (identityProviders.isEmpty()) {
+            throw new IllegalArgumentException("invalid configuration: no defined upstream spid idps");
+        }
+
+        this.identityProviders = identityProviders;
     }
 
     /*
-     * getBareRelyingPartyRegistration yields a single relying party registration 
+     * getRelyingPartyRegistration yields a single relying party registration 
      * with registration id equal to the encoded providerId.
      * This is required for cases where the registration does not require any asserting party details,
      * such as SPID metadata.
      */
     @JsonIgnore
-    public RelyingPartyRegistration getBareRelyingPartyRegistration() {
-        if (bareRelyingPartyRegistration == null) {
-            try {
-                bareRelyingPartyRegistration = toBareRelyingPartyRegistration();
-            } catch (IOException | CertificateException e) {
-                throw new RuntimeException("error building registration: " + e.getMessage());
-            }
-        }
-        return bareRelyingPartyRegistration;
-    }
+    public RelyingPartyRegistration getRelyingPartyRegistration() {
+        if (relyingPartyRegistrations != null) {
+            String registrationId = getMetadataRegistrationId();
+            RelyingPartyRegistration r = relyingPartyRegistrations
+                .stream()
+                .filter(reg -> reg.getRegistrationId().equals(registrationId))
+                .findFirst().orElse(null);
 
-    /*
-     * getRelyingPartyRegistrations yields a set of relying party registrations;
-     * one for each configured upstream identity provider
-     */
-    @JsonIgnore
-    public Set<RelyingPartyRegistration> getRelyingPartyRegistrations() {
-        if (relyingPartyRegistrations == null) {
-            try {
-                relyingPartyRegistrations = toRelyingPartyRegistrations();
-            } catch (IOException | CertificateException e) {
-                throw new RuntimeException("error building registration: " + e.getMessage());
+            if (r != null) {
+                return r;
             }
         }
-        return relyingPartyRegistrations;
+
+        try {
+            RelyingPartyRegistration r = toBareRelyingPartyRegistration();
+            if (relyingPartyRegistrations == null) {
+                relyingPartyRegistrations = new HashSet<>();
+            }
+            relyingPartyRegistrations.add(r);
+            return r;
+        } catch (IOException | CertificateException e) {
+            throw new RuntimeException("error building registration: " + e.getMessage());
+        }
     }
 
     /*
@@ -285,46 +322,30 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
      */
     @JsonIgnore
     public RelyingPartyRegistration getRelyingPartyRegistration(String idpKey) {
-        if (relyingPartyRegistrations == null) {
-            try {
-                String idpMetadataUrl = getAssertingPartyMetadataUrl(idpKey);
-                return toRelyingPartyRegistration(idpMetadataUrl);
-            } catch (IOException | CertificateException | URISyntaxException e) {
-                throw new RuntimeException("error building registration: " + e.getMessage());
-            }
-        }
-        String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(idpKey));
-        return relyingPartyRegistrations
+        if (relyingPartyRegistrations != null) {
+            String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(idpKey));
+            RelyingPartyRegistration r = relyingPartyRegistrations
                 .stream()
                 .filter(reg -> reg.getRegistrationId().equals(registrationId))
-                .findAny()
-                .orElse(null);
-    }
+                .findFirst().orElse(null);
 
-    // generate a registration (an RP/AP pair as defined by OpenSaml) for each configured upstream idps
-    private Set<RelyingPartyRegistration> toRelyingPartyRegistrations() throws IOException, CertificateException {
-        Set<RelyingPartyRegistration> registrations = new HashSet<>();
-        try {
-            Set<String> idpMetadataUrls = getAssertingPartyMetadataUrls();
-            for (String idpMetadataUrl : idpMetadataUrls) {
-                try {
-                    registrations.add(toRelyingPartyRegistration(idpMetadataUrl));
-                } catch (Saml2Exception | ConnectException e) {
-                    // skip that registration if that idp is offline
-                }
+            if (r != null) {
+                return r;
             }
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("spid provider failed to invalid metadata uri: " + e.getMessage());
         }
 
-        if (registrations.isEmpty()) {
-            throw new IllegalArgumentException(
-                "invalid configuration: failed to acquire any relaying party registration for spid provider " +
-                getProvider()
-            );
+        try {
+            String idpMetadataUrl = getAssertingPartyMetadataUrl(idpKey);
+            String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(idpMetadataUrl)));
+            RelyingPartyRegistration r = toRelyingPartyRegistration(registrationId, idpMetadataUrl);
+            if (relyingPartyRegistrations == null) {
+                relyingPartyRegistrations = new HashSet<>();
+            }
+            relyingPartyRegistrations.add(r);
+            return r;
+        } catch (IOException | CertificateException | URISyntaxException e) {
+            throw new RuntimeException("error building registration: " + e.getMessage());
         }
-
-        return registrations;
     }
 
     // create a relying party registration with placeholder ap configuration.
@@ -360,9 +381,8 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
 
     // create a relying party registration for an upstream idp; only ap autoconfiguration is supported,
     // hence function parameters require an idp metadata url
-    private RelyingPartyRegistration toRelyingPartyRegistration(String idpMetadataUrl) throws IOException, CertificateException, URISyntaxException {
+    private RelyingPartyRegistration toRelyingPartyRegistration(String registrationId, String idpMetadataUrl) throws IOException, CertificateException {
         // start from ap autoconfiguration ...
-        String registrationId = encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(idpMetadataUrl)));
         RelyingPartyRegistration.Builder builder = RelyingPartyRegistrations
             .fromMetadataLocation(idpMetadataUrl)
             .registrationId(registrationId);
@@ -395,10 +415,13 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     // the function might throws an exception if the provided the metadata url is not
     // a valid uri
     public String evalIdpKeyIdentifier(String idpMetadataUrl) throws URISyntaxException {
-        Optional<SpidRegistration> reg =
-            this.identityProviders.values().stream().filter(r -> r.getMetadataUrl().equals(idpMetadataUrl)).findFirst();
-        if (reg.isPresent()) {
-            return reg.get().getEntityId();
+        SpidRegistration reg = identityProviders
+            .stream()
+            .filter(idp -> idp.getMetadataUrl().equals(idpMetadataUrl))
+            .findFirst().orElse(null);;
+
+        if (reg != null) {
+            return reg.getEntityId();
         }
         return new URI(idpMetadataUrl).getHost();
     }
@@ -433,7 +456,7 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     @JsonIgnore
     public List<Credential> getRelyingPartySigningCredentials() {
         List<Credential> credentials = new ArrayList<>();
-        RelyingPartyRegistration rp = getBareRelyingPartyRegistration();
+        RelyingPartyRegistration rp = getRelyingPartyRegistration();
         if (rp == null) {
             return credentials;
         }
@@ -514,60 +537,25 @@ public class SpidIdentityProviderConfig extends AbstractIdentityProviderConfig<S
     }
 
     public Set<String> getRelyingPartyRegistrationIds() {
-        Set<String> idpMetadataUrls = getAssertingPartyMetadataUrls();
-        Set<String> ids = idpMetadataUrls
-            .stream()
-            .map(u -> {
-                try {
-                    return encodeRegistrationId(evalRelyingPartyRegistrationId(evalIdpKeyIdentifier(u)));
-                } catch (URISyntaxException e) {
-                    throw new IllegalArgumentException("invalid metadata uri " + e.getMessage());
-                }
-            })
-            .collect(Collectors.toSet());
+        Set<String> ids = new HashSet<>();
+
+        identityProviders.stream().forEach(
+            idp -> ids.add(encodeRegistrationId(evalRelyingPartyRegistrationId(idp.getEntityId())))
+        );
         ids.add(getMetadataRegistrationId());
         return ids;
     }
 
-    // returns the list of metadata urls of upstream idps
-    private Set<String> getAssertingPartyMetadataUrls() {
-        Set<String> idpMetadataUrls = new HashSet<>();
-
-        // idp urls must be defined by either in configMap or application config (and passed to this.idps)
-        if (StringUtils.hasText(configMap.getIdpMetadataUrl())) {
-            // single idp via url
-            idpMetadataUrls = Collections.singleton(configMap.getIdpMetadataUrl());
-            return idpMetadataUrls;
+    private String getAssertingPartyMetadataUrl(String idpEntityId) {
+        SpidRegistration reg = identityProviders
+            .stream()
+            .filter(idp -> idp.getEntityId().equals(idpEntityId))
+            .findFirst().orElse(null);
+        
+        if (reg != null) {
+            return reg.getMetadataUrl();
         }
-        if (identityProviders == null) {
-            throw new IllegalArgumentException("invalid configuration: no defined upstream spid idps");
-        }
-        // if config map defined some specific idps, pick those, otherwise pick all
-        if (configMap.getIdps() != null && !configMap.getIdps().isEmpty()) {
-            for (String idp : configMap.getIdps()) {
-                SpidRegistration reg = identityProviders.get(idp);
-                if (reg != null) {
-                    idpMetadataUrls.add(reg.getMetadataUrl());
-                }
-            }
-        } else {
-            for (SpidRegistration reg : identityProviders.values()) {
-                idpMetadataUrls.add(reg.getMetadataUrl());
-            }
-        }
-        if (idpMetadataUrls.isEmpty()) {
-            throw new IllegalArgumentException("invalid configuration: no defined upstream spid idps");
-        }
-        return idpMetadataUrls;
-    }
-
-    private String getAssertingPartyMetadataUrl(String idpKey) {
-        // idp urls must be defined by either in configMap or application config (and passed to this.idps)
-        if (StringUtils.hasText(configMap.getIdpMetadataUrl())) {
-            // single idp via url
-            return configMap.getIdpMetadataUrl();
-        }
-        return identityProviders.get(idpKey).getMetadataUrl();
+        return null;
     }
 
     private void loadMetadataConfiguration() {

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfigMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderConfigMap.java
@@ -44,31 +44,24 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         SystemKeys.ID_SEPARATOR +
         SystemKeys.AUTHORITY_SPID;
 
-    // core
-    private String entityId;
-
     // <Signature> options
     private String signingKey;
-
     private String signingCertificate; // for <KeyDescriptor use="signing"><KeyInfo>
 
-    // <Organization> options (suggested but not mandatory)
-    private String organizationDisplayName;
-
+    private String metadataUrl;
+    private String metadataXML;
+    
+    private String entityId;
     private String organizationName;
-
+    private String organizationDisplayName;
     private String organizationUrl;
 
-    // <ContactPerson> options, only public SP is currently supported
     @Pattern(regexp = SystemKeys.EMAIL_PATTERN)
-    private String contactPerson_EmailAddress;
-
+    private String contactPersonEmailAddress;
     @Pattern(regexp = "^[A-Za-z0-9_]*$")
-    private String contactPerson_IPACode;
+    private String contactPersonIPACode;
 
-    private Boolean contactPerson_Public; // Public/Private
-
-    private String contactPerson_Type; // "other" (mandatory), optionally includes "billing" (unless private SP, in which case "billing" is also mandatory)
+    private Set<SpidAttribute> spidAttributes;
 
     // AAC options
     // NOTE: only one among {idps, idpMetadataUrl} can be non null
@@ -76,21 +69,13 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
     //  to be used for testing purposes. If both are null, the full local SPID registry will be used instead.
     private Set<String> idps; // optional (see note above)
     private String idpMetadataUrl; // optional (see note above)
-    private Set<SpidAttribute> spidAttributes; // optional
 
     private Boolean useAssertionConsumerServiceUrl;
+    private Integer attributeConsumingServiceIndex;
     private SpidAuthnContext authnContext;
 
     private SpidUserAttribute subAttributeName; // optional
     private SpidUserAttribute usernameAttributeName; // optional
-
-    public String getEntityId() {
-        return entityId;
-    }
-
-    public void setEntityId(String entityId) {
-        this.entityId = entityId;
-    }
 
     public String getSigningKey() {
         return signingKey;
@@ -108,44 +93,28 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.signingCertificate = signingCertificate;
     }
 
-    public String getContactPerson_EmailAddress() {
-        return contactPerson_EmailAddress;
+    public String getMetadataUrl() {
+        return metadataUrl;
     }
 
-    public void setContactPerson_EmailAddress(String contactPerson_EmailAddress) {
-        this.contactPerson_EmailAddress = contactPerson_EmailAddress;
+    public void setMetadataUrl(String metadataUrl) {
+        this.metadataUrl = metadataUrl;
     }
 
-    public String getContactPerson_IPACode() {
-        return contactPerson_IPACode;
+    public String getMetadataXML() {
+        return metadataXML;
     }
 
-    public void setContactPerson_IPACode(String contactPerson_IPACode) {
-        this.contactPerson_IPACode = contactPerson_IPACode;
+    public void setMetadataXML(String metadataXML) {
+        this.metadataXML = metadataXML;
     }
 
-    public Boolean getContactPerson_Public() {
-        return contactPerson_Public;
+    public String getEntityId() {
+        return entityId;
     }
 
-    public void setContactPerson_Public(Boolean contactPerson_Public) {
-        this.contactPerson_Public = contactPerson_Public;
-    }
-
-    public String getContactPerson_Type() {
-        return contactPerson_Type;
-    }
-
-    public void setContactPerson_Type(String contactPerson_Type) {
-        this.contactPerson_Type = contactPerson_Type;
-    }
-
-    public String getOrganizationDisplayName() {
-        return organizationDisplayName;
-    }
-
-    public void setOrganizationDisplayName(String organizationDisplayName) {
-        this.organizationDisplayName = organizationDisplayName;
+    public void setEntityId(String entityId) {
+        this.entityId = entityId;
     }
 
     public String getOrganizationName() {
@@ -156,12 +125,44 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.organizationName = organizationName;
     }
 
+    public String getOrganizationDisplayName() {
+        return organizationDisplayName;
+    }
+
+    public void setOrganizationDisplayName(String organizationDisplayName) {
+        this.organizationDisplayName = organizationDisplayName;
+    }
+
     public String getOrganizationUrl() {
         return organizationUrl;
     }
 
     public void setOrganizationUrl(String organizationUrl) {
         this.organizationUrl = organizationUrl;
+    }
+
+    public String getContactPersonEmailAddress() {
+        return contactPersonEmailAddress;
+    }
+
+    public void setContactPersonEmailAddress(String contactPersonEmailAddress) {
+        this.contactPersonEmailAddress = contactPersonEmailAddress;
+    }
+
+    public String getContactPersonIPACode() {
+        return contactPersonIPACode;
+    }
+
+    public void setContactPersonIPACode(String contactPersonIPACode) {
+        this.contactPersonIPACode = contactPersonIPACode;
+    }
+
+    public Set<SpidAttribute> getSpidAttributes() {
+        return spidAttributes;
+    }
+
+    public void setSpidAttributes(Set<SpidAttribute> spidAttributes) {
+        this.spidAttributes = spidAttributes;
     }
 
     public Set<String> getIdps() {
@@ -180,20 +181,20 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
         this.idpMetadataUrl = idpMetadataUrl;
     }
 
-    public Set<SpidAttribute> getSpidAttributes() {
-        return spidAttributes;
-    }
-
-    public void setSpidAttributes(Set<SpidAttribute> spidAttributes) {
-        this.spidAttributes = spidAttributes;
-    }
-
     public Boolean getUseAssertionConsumerServiceUrl() {
         return useAssertionConsumerServiceUrl;
     }
 
     public void setUseAssertionConsumerServiceUrl(Boolean useAssertionConsumerServiceUrl) {
         this.useAssertionConsumerServiceUrl = useAssertionConsumerServiceUrl;
+    }
+
+    public Integer getAttributeConsumingServiceIndex() {
+        return attributeConsumingServiceIndex;
+    }
+
+    public void setAttributeConsumingServiceIndex(Integer attributeConsumingServiceIndex) {
+        this.attributeConsumingServiceIndex = attributeConsumingServiceIndex;
     }
 
     public SpidAuthnContext getAuthnContext() {
@@ -222,20 +223,21 @@ public class SpidIdentityProviderConfigMap extends AbstractConfigMap implements 
 
     @JsonIgnore
     public void setConfiguration(SpidIdentityProviderConfigMap map) {
-        this.entityId = map.getEntityId();
         this.signingKey = map.getSigningKey();
-        this.signingCertificate = map.getSigningKey();
-        this.contactPerson_EmailAddress = map.getContactPerson_EmailAddress();
-        this.contactPerson_IPACode = map.getContactPerson_IPACode();
-        this.contactPerson_Public = map.getContactPerson_Public();
-        this.contactPerson_Type = map.getContactPerson_Type();
-        this.organizationDisplayName = map.getOrganizationDisplayName();
+        this.signingCertificate = map.getSigningCertificate();
+        this.metadataUrl = map.getMetadataUrl();
+        this.metadataXML = map.getMetadataXML();
+        this.entityId = map.getEntityId();
         this.organizationName = map.getOrganizationName();
+        this.organizationDisplayName = map.getOrganizationDisplayName();
         this.organizationUrl = map.getOrganizationUrl();
+        this.contactPersonEmailAddress = map.getContactPersonEmailAddress();
+        this.contactPersonIPACode = map.getContactPersonIPACode();
+        this.spidAttributes = map.getSpidAttributes();
         this.idps = map.getIdps();
         this.idpMetadataUrl = map.getIdpMetadataUrl();
-        this.spidAttributes = map.getSpidAttributes();
         this.useAssertionConsumerServiceUrl = map.getUseAssertionConsumerServiceUrl();
+        this.attributeConsumingServiceIndex = map.getAttributeConsumingServiceIndex();
         this.authnContext = map.getAuthnContext();
         this.subAttributeName = map.getSubAttributeName();
         this.usernameAttributeName = map.getUsernameAttributeName();

--- a/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/spid/provider/SpidIdentityProviderStatusMap.java
@@ -42,15 +42,8 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
         SystemKeys.AUTHORITY_SPID;
 
     private String metadataUrl;
-    private Map<String, String> assertionConsumerUrls;
-
-    public Map<String, String> getAssertionConsumerUrls() {
-        return assertionConsumerUrls;
-    }
-
-    public void setAssertionConsumerUrls(Map<String, String> assertionConsumerUrls) {
-        this.assertionConsumerUrls = assertionConsumerUrls;
-    }
+    private String assertionConsumerUrl;
+    private Map<String, String> metadataConfiguration;
 
     public String getMetadataUrl() {
         return metadataUrl;
@@ -60,12 +53,29 @@ public class SpidIdentityProviderStatusMap extends AbstractStatusMap {
         this.metadataUrl = metadataUrl;
     }
 
+    public String getAssertionConsumerUrl() {
+        return assertionConsumerUrl;
+    }
+
+    public void setAssertionConsumerUrl(String assertionConsumerUrl) {
+        this.assertionConsumerUrl = assertionConsumerUrl;
+    }
+
+    public Map<String, String> getMetadataConfiguration() {
+        return metadataConfiguration;
+    }
+
+    public void setMetadataConfiguration(Map<String, String> metadataConfiguration) {
+        this.metadataConfiguration = metadataConfiguration;
+    }
+
     public SpidIdentityProviderStatusMap() {}
 
     @JsonIgnore
     public void setConfiguration(SpidIdentityProviderStatusMap map) {
         this.metadataUrl = map.getMetadataUrl();
-        this.assertionConsumerUrls = map.getAssertionConsumerUrls();
+        this.assertionConsumerUrl = map.getAssertionConsumerUrl();
+        this.metadataConfiguration = map.getMetadataConfiguration();
     }
 
     @Override

--- a/src/main/resources/public/html/provider/idp.conf.spid.html
+++ b/src/main/resources/public/html/provider/idp.conf.spid.html
@@ -18,13 +18,6 @@
                 </div>
             </div>        
         </div>
-        <div class="row">
-             <div class="form-group col">
-                <label for="entityId">Entity ID</label>
-                <input type="text" name="entityId" class="form-control form-control-sm" id="entityId"
-                    ng-model="idp.configuration.entityId">
-            </div>
-        </div>
         <div class="py-3">Signing</div>
         <div class="row">
             <div class="form-group col ">
@@ -44,28 +37,47 @@
     <fieldset>
         <legend class="mb-4">SPID Registration</legend>
         <div class="row">
+             <div class="form-group col">
+                <label for="metadataUrl">Metadata Url</label>
+                <input type="text" name="metadataUrl" class="form-control form-control-sm" id="metadataUrl"
+                    ng-model="idp.configuration.metadataUrl">
+            </div>
+        </div>
+        <div class="row">
+            <div class="form-group col ">
+                <label for="metadataXML">Metadata XML</label>
+                <textarea rows="5" id="metadataXML" name="metadataXML"
+                    ng-model="idp.configuration.metadataXML"></textarea>
+            </div>
+        </div>
+        <div class="row">
+            <div class="form-group col">
+                <label for="entityId">Entity ID</label>
+                <input type="text" name="entityId" class="form-control form-control-sm" id="entityId"
+                    ng-model="idp.configuration.entityId">
+            </div>
+        </div>
+        <div class="row">
             <div class="pt-0 mb-4 col-md-12"> Organization information </div>
             <div class="form-group col">
                 <div class="input-group">
                     <label for="organizationName">Organization name</label>
-                    <input type="text" required class="form-control" id="organizationName"
+                    <input type="text" class="form-control" id="organizationName"
                         ng-model="idp.configuration.organizationName">
                 </div>
             </div>
             <div class="form-group col">
                 <div class="input-group">
-                    <label for="organizationUrl">Organization url</label>
-                    <input type="text" required class="form-control" id="organizationUrl"
-                        ng-model="idp.configuration.organizationUrl">
+                    <label for="organizationDisplayName">Organization display name</label>
+                    <input type="text" class="form-control" id="organizationDisplayName"
+                        ng-model="idp.configuration.organizationDisplayName">
                 </div>
             </div>
-        </div>
-        <div class="row">
             <div class="form-group col">
                 <div class="input-group">
-                    <label for="organizationDisplayName">Organization display name</label>
-                    <input type="text" required class="form-control" id="organizationDisplayName"
-                        ng-model="idp.configuration.organizationDisplayName">
+                    <label for="organizationUrl">Organization url</label>
+                    <input type="text" class="form-control" id="organizationUrl"
+                        ng-model="idp.configuration.organizationUrl">
                 </div>
             </div>
         </div>
@@ -74,28 +86,37 @@
             <div class="form-group col">
                 <div class="input-group">
                     <label for="contactPersonEmailAddress">Contact person email</label>
-                    <input type="text" required class="form-control" id="contactPersonEmailAddress"
-                        ng-model="idp.configuration.contactPerson_EmailAddress">
-                </div>
-            </div>
-            <div class="form-group col">
-                <div class="input-group">
-                    <label for="contactPersonTelephoneNumber">Contact person phone</label>
-                    <input type="text" class="form-control" id="contactPersonTelephoneNumber"
-                        ng-model="idp.configuration.contactPerson_Telephone">
+                    <input type="text" class="form-control" id="contactPersonEmailAddress"
+                        ng-model="idp.configuration.contactPersonEmailAddress">
                 </div>
             </div>
             <div class="form-group col">
                 <div class="input-group">
                     <label for="contactPersonIPACode">Contact person IPAcode</label>
-                    <input type="text" required class="form-control" id="contactPersonIPACode"
-                           ng-model="idp.configuration.contactPerson_IPACode">
+                    <input type="text" class="form-control" id="contactPersonIPACode"
+                           ng-model="idp.configuration.contactPersonIPACode">
                 </div>
             </div>
         </div>
     </fieldset>
     <fieldset>
         <legend class="mb-4">SPID Advanced Configuration</legend>
+        <div class="row">
+            <div class="form-group col">
+                <div class="form-check">
+                    <label for="useAssertionConsumerServiceUrl">Use Assertion Consumer Service Url</label>
+                    <input type="checkbox" class="form-check-input" id="useAssertionConsumerServiceUrl" name="useAssertionConsumerServiceUrl"
+                        ng-model="idp.configuration.useAssertionConsumerServiceUrl">
+                </div>
+            </div>
+            <div class="form-group col">
+                <div class="form-check">
+                    <label for="attributeConsumingServiceIndex">Attribute Consuming Service Index</label>
+                    <input type="number" name="attributeConsumingServiceIndex" min="0" class="form-control form-control-sm"
+                        id="attributeConsumingServiceIndex" ng-model="idp.configuration.attributeConsumingServiceIndex">
+                </div>
+            </div>
+        </div>
         <div class="row">
             <div class="form-group col">
                 <div class="bootstrap-select-wrapper border-bottom-0">


### PR DESCRIPTION
This pull request introduces the following new features for SPID identity providers

- The ability, during provider configuration, to use an external metadata instead of exposing a locally configured one. Configuring the external metadata can be done either by specifying the URL to download the metadata or by directly inserting the metadata XML in the configmap. Configuring external metadata includes certificate validation between the provider's configured certificate and the one presented in the metadata.
- The capability to configure the AttributeConsumingServiceIndex used in SAML requests. When using external metadata, the configured value is validated against the AttributeConsumingServices defined in the metadata.
- A more informative status map that includes information from the metadata exposed by the provider or, in the case of external metadata, the metadata with which the provider is configured.
- A minor refactor of the Relying Party Registrations to improve the provider's performance.
- A fix allowing configuration of the use of a single upstream identity provider by defining its metadata URL in the "idpMetadataUrl" parameter.