### PR TITLE
Fix test pollution and state leakage in `TosConfigTest`

### DIFF
--- a/src/test/java/it/smartcommunitylab/aac/tos/TosConfigTest.java
+++ b/src/test/java/it/smartcommunitylab/aac/tos/TosConfigTest.java
@@ -26,6 +26,7 @@ import it.smartcommunitylab.aac.common.NoSuchRealmException;
 import it.smartcommunitylab.aac.dto.RealmConfig;
 import it.smartcommunitylab.aac.model.Realm;
 import it.smartcommunitylab.aac.realms.service.RealmService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -64,6 +65,15 @@ public class TosConfigTest {
 
             slug = rc.getRealm().getSlug();
             assertThat(slug).isNotBlank();
+        }
+    }
+
+    @AfterEach
+    public void cleanUp() throws NoSuchRealmException {
+        if (slug != null) {
+            TosConfigurationMap configMap = new TosConfigurationMap();
+            configMap.setEnableTOS(null);
+            updateTos(slug, configMap);
         }
     }
 


### PR DESCRIPTION
### Description
This PR addresses the state leakage issue in the Terms of Service (ToS) integration tests. While `TosUserTest` already handled cleanup, `TosConfigTest` was missing a teardown mechanism, causing the `Realm` configuration (persisted via `RealmService`) to remain in a "dirty" state between test executions.

I have implemented an `@AfterEach` method in `TosConfigTest` to ensure that the ToS configuration is reset to a baseline state (ToS disabled/null) after every test case.

### Related Issues
- Fixes #763

### Changes
* **`TosConfigTest.java`**: Added `cleanUp()` method annotated with `@AfterEach`.
* The cleanup logic uses `TosConfigurationMap` to set `enableTOS` to `null` and updates the realm via `realmService`, mirroring the robust cleanup pattern used in `TosUserTest`.

### Verification Results
- **Test Isolation**: Verified that running `termsPageIsPublicWhenEnabled` no longer leaves the realm enabled for subsequent tests.
- **Suite Stability**: The tests now pass regardless of their execution order, as each test starts/ends with a predictable realm configuration.
- **Consistency**: The cleanup approach is now consistent across all ToS-related test classes.