### PR TITLE
feat: change notes-idpsettings in textarea

### DIFF
--- a/dev-console/src/idps/schemas.ts
+++ b/dev-console/src/idps/schemas.ts
@@ -104,6 +104,9 @@ export const schemaIdpSettings: RJSFSchema = {
 
 export const uiSchemaIdpSettings: UiSchema = {
     'ui:layout': [12],
+    notes: {
+        'ui:widget': 'textarea',
+    },
 };
 
 export const uiSchemaInternalIdp: UiSchema = {


### PR DESCRIPTION
Changed the "Notes" field in the IdP settings from a single-line label to a multiline textarea to make editing and reading long texts much easier.