### PR TITLE
fix: add active signing credentials label to console

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -587,6 +587,10 @@
         "name": "Signing Credential Id",
         "helperText": "Unique identifier for the credential"
     },
+    "activeSigningCredentialId": {
+        "name": "Active Signing Credential Id",
+        "helperText": "If not specified or incorrect, the first credential will be selected"
+    },
     "activeAuthRequestSigningCredentialId": {
         "name": "Active AuthRequest Signing Credential Id",
         "helperText": "If not specified or not found in the list, the system will fall back to the standalone-signingKey and standalone-signingCertificate configuration, and finally to the first credential in the list."


### PR DESCRIPTION
This pull request closes issue #687.
