### PR TITLE
fix: update email validation regex for account forms

### DIFF
--- a/src/main/resources/templates/internal/changeaccount.html
+++ b/src/main/resources/templates/internal/changeaccount.html
@@ -55,7 +55,7 @@
             <div class="col-md-12 form-group">
                <label th:text="#{field.email} + '*: '"></label>
                <input type="text" class="form-control" th:field="*{email}"
-                  pattern="[\w.+~-]+@[\w.+-]+\.[a-zA-Z]{2,}$" />
+                  pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" />
                <div class="invalid-feedback" th:if="${#fields.hasErrors('email')}" th:errors="*{email}">
                </div>
             </div>

--- a/src/main/resources/templates/internal/registeraccount.html
+++ b/src/main/resources/templates/internal/registeraccount.html
@@ -56,7 +56,7 @@
             <div class="col-md-12 form-group">
                <label th:text="#{field.email} + '*: '"></label>
                <input type="text" class="form-control" th:field="*{email}"
-                  pattern="[\w.+~-]+@[\w.+-]+\.[a-zA-Z]{2,}$" />
+                  pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" />
                <div class="invalid-feedback" th:if="${#fields.hasErrors('email')}" th:errors="*{email}">
                </div>
             </div>

--- a/src/main/resources/templates/password/resetpwd.html
+++ b/src/main/resources/templates/password/resetpwd.html
@@ -43,7 +43,7 @@
          <div class="col-md-12 form-group">
             <label th:text="#{field.email} + '*: '"></label>
             <input type="text" class="form-control" th:field="*{email}"
-               pattern="[\w.+~-]+@[\w.+-]+\.[a-zA-Z]{2,}$" />
+               pattern="[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$" />
             <div class="invalid-feedback" th:if="${#fields.hasErrors('email')}" th:errors="*{email}"></div>
          </div>
 


### PR DESCRIPTION
Updated the email input pattern in changeaccount.html, registeraccount.html, and resetpwd.html to use a regex aligned with RFC 5322 policy