### PR TITLE
refactor: relax email validation to be RFC 5322-compliant

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
+++ b/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
@@ -121,7 +121,7 @@ public class SystemKeys {
 
     public static final String SLUG_PATTERN = "^[a-zA-Z0-9._-]+$";
     public static final String ID_PATTERN = "^[a-zA-Z0-9_-|]+$";
-    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._@-]+$";
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String SCOPE_PATTERN = "^[a-zA-Z.:_-]{3,}$";
     public static final String RESOURCE_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String NAMESPACE_PATTERN = "^[a-zA-Z0-9._:/-]+$";

--- a/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
+++ b/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
@@ -121,7 +121,7 @@ public class SystemKeys {
 
     public static final String SLUG_PATTERN = "^[a-zA-Z0-9._-]+$";
     public static final String ID_PATTERN = "^[a-zA-Z0-9_-|]+$";
-    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._@-]+$";
     public static final String SCOPE_PATTERN = "^[a-zA-Z.:_-]{3,}$";
     public static final String RESOURCE_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String NAMESPACE_PATTERN = "^[a-zA-Z0-9._:/-]+$";

--- a/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
+++ b/src/main/java/it/smartcommunitylab/aac/SystemKeys.java
@@ -121,7 +121,8 @@ public class SystemKeys {
 
     public static final String SLUG_PATTERN = "^[a-zA-Z0-9._-]+$";
     public static final String ID_PATTERN = "^[a-zA-Z0-9_-|]+$";
-    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._@-]+$";
+    // Reference: https://www.rfc-editor.org/info/rfc5322/#section-3.2.3
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String SCOPE_PATTERN = "^[a-zA-Z.:_-]{3,}$";
     public static final String RESOURCE_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String NAMESPACE_PATTERN = "^[a-zA-Z0-9._:/-]+$";

--- a/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
@@ -683,7 +683,7 @@ public class OAuth2RequestFactory
 
     public static final String SLUG_PATTERN = SystemKeys.SLUG_PATTERN;
     public static final String STRING_PATTERN = "^[a-zA-Z0-9_:-]+$";
-    public static final String EMAIL_PATTERN = SystemKeys.EMAIL_PATTERN;
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String URI_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String SPECIAL_PATTERN = "^[a-zA-Z0-9_!=@$&%():/\\-`.+,/\"]*$";
     public static final String SPACE_STRING_PATTERN = "^[a-zA-Z0-9 _:-]+$";

--- a/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
@@ -683,6 +683,7 @@ public class OAuth2RequestFactory
 
     public static final String SLUG_PATTERN = SystemKeys.SLUG_PATTERN;
     public static final String STRING_PATTERN = "^[a-zA-Z0-9_:-]+$";
+    // Reference: https://www.rfc-editor.org/info/rfc5322/#section-3.2.3
     public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String URI_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String SPECIAL_PATTERN = "^[a-zA-Z0-9_!=@$&%():/\\-`.+,/\"]*$";


### PR DESCRIPTION
Addresses Issue #588 by updating the email validation regex to be RFC 5322-compliant.

Changes:
- SystemKeys: Updated the global regex pattern to support broader characters system-wide.
- OAuth2 Flow: Maintained an isolated, standalone regex string specifically for the OAuth2 validation flow, keeping it separate from SystemKeys.