### PR TITLE
fix: correct constructor call in SecureStringKeyGenerator

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/common/SecureStringKeyGenerator.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/common/SecureStringKeyGenerator.java
@@ -35,7 +35,7 @@ public class SecureStringKeyGenerator implements StringKeyGenerator {
     }
 
     public SecureStringKeyGenerator(int keyLength) {
-        this(DEFAULT_KEY_LENGTH, DEFAULT_ENCODE_CHARSET);
+        this(keyLength, DEFAULT_ENCODE_CHARSET);
     }
 
     public SecureStringKeyGenerator(int keyLength, Charset charset) {


### PR DESCRIPTION
Fixes #807

## Summary of Changes
Fixed constructor delegation in `SecureStringKeyGenerator(int keyLength)` so that it passes the custom `keyLength` parameter to the main constructor instead of overriding it with `DEFAULT_KEY_LENGTH`.