### PR TITLE
Feat: Dynamic Audit Logging & Token Grant Refactoring

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -274,6 +274,10 @@
         "helperText": "",
         "name": "Audit events"
     },
+    "oauth2EventsLevel": {
+        "helperText": "Detail level for OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT) in this realm. Leave empty to keep the default (none).",
+        "name": "OAuth2 token events level"
+    },
     "linkable": {
         "helperText": "",
         "name": "Enable account linking"

--- a/dev-console/src/i18n/en/pages.json
+++ b/dev-console/src/i18n/en/pages.json
@@ -254,6 +254,12 @@
         "header": "Login"
     },
     "realm": {
+        "audit": {
+            "header": {
+                "subtitle": "Configure the detail level of OAuth2 token grant audit events",
+                "title": "Audit"
+            }
+        },
         "developers": {
             "header": {
                 "title": "Developers"

--- a/dev-console/src/myrealms/RealmEdit.tsx
+++ b/dev-console/src/myrealms/RealmEdit.tsx
@@ -19,6 +19,7 @@ import { RefreshingExportButton } from '../components/RefreshingExportButton';
 import { ResourceTitle } from '../components/ResourceTitle';
 import SettingsIcon from '@mui/icons-material/Settings';
 import {
+    realmAuditSchema,
     realmLocalizationSchema,
     realmOAuthSchema,
     realmTosSchema,
@@ -160,6 +161,18 @@ const RealmEditForm = () => {
                 <JsonSchemaInput
                     source="tosConfiguration"
                     schema={realmTosSchema}
+                />
+            </TabbedForm.Tab>
+            <TabbedForm.Tab label="tab.audit">
+                <SectionTitle
+                    text={translate('page.realm.audit.header.title')}
+                    secondaryText={translate(
+                        'page.realm.audit.header.subtitle'
+                    )}
+                />
+                <JsonSchemaInput
+                    source="auditConfiguration"
+                    schema={realmAuditSchema}
                 />
             </TabbedForm.Tab>
             <TabbedForm.Tab label="tab.developers">

--- a/dev-console/src/myrealms/schemas.ts
+++ b/dev-console/src/myrealms/schemas.ts
@@ -59,3 +59,15 @@ export const realmTosSchema: RJSFSchema = {
         },
     },
 };
+
+export const realmAuditSchema: RJSFSchema = {
+    type: 'object',
+    properties: {
+        oauth2EventsLevel: {
+            type: 'string',
+            enum: ['none', 'minimal', 'details', 'full'],
+            title: 'field.oauth2EventsLevel.name',
+            description: 'field.oauth2EventsLevel.helperText',
+        },
+    },
+};

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,6 +16,8 @@
 
 package it.smartcommunitylab.aac.audit;
 
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.audit.helper.AuditHelperMethods;
 import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.event.OAuth2AuthorizationExceptionEvent;
@@ -24,9 +26,12 @@ import it.smartcommunitylab.aac.oauth.event.OAuth2TokenExceptionEvent;
 import it.smartcommunitylab.aac.oauth.event.TokenGrantEvent;
 import it.smartcommunitylab.aac.oauth.model.OAuth2ClientDetails;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -53,9 +58,15 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
 
     private final OAuth2ClientDetailsService clientService;
 
+    private RealmService realmService;
+
     public OAuth2EventListener(OAuth2ClientDetailsService clientService) {
         Assert.notNull(clientService, "client service is required");
         this.clientService = clientService;
+    }
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
     }
 
     @Override
@@ -147,32 +158,59 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
             AACOAuth2AccessToken token = (AACOAuth2AccessToken) event.getToken();
             OAuth2Authentication auth = event.getAuthentication();
             OAuth2ClientAuthenticationToken authClient = event.getClientAuthentication();
-            Authentication authUser = auth.getUserAuthentication();
+            Authentication rawAuthentication = auth.getUserAuthentication();
 
-            //            String principal = auth.getName();
             String principal = token.getSubject();
             if (!StringUtils.hasText(principal)) {
                 principal = auth.getName();
             }
 
             String realm = token.getRealm();
-            String type = auth.getUserAuthentication() == null ? "client" : "user";
+            // realm level detail configuration
+            String levelRealmEvent = AuditHelperMethods.resolveOauth2EventsLevel(realmService, realm);
 
-            Map<String, Object> data = new HashMap<>();
-            Map<String, Object> webAuthenticationDetails = new HashMap<>();
-
-            if (authClient != null && authClient.getWebAuthenticationDetails() != null) {
-                webAuthenticationDetails.put("client", authClient.getWebAuthenticationDetails());
+            if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_NONE)) {
+                return;
             }
 
-            if (authUser != null && authUser.getDetails() != null) {
-                webAuthenticationDetails.put("user", authUser.getDetails());
+            // use LinkedHashMap so the serialized audit JSON preserves this insertion order
+            Map<String, Object> data = new LinkedHashMap<>();
+
+            // TOKEN GRANT TYPE
+            if (StringUtils.hasText(event.getGrantType())) {
+                data.put("grant_type", event.getGrantType());
             }
 
-            data.put("webAuthenticationDetails", webAuthenticationDetails);
+            // ISSUED TOKENS
+            List<String> issuedTokens = AuditHelperMethods.issuedTokens(token, event);
+            data.put("issued_tokens", issuedTokens);
 
-            data.put("type", type);
-            data.put("token", token.getValue());
+            // IP ADDRESS OF CLIENT THAT REQUIRE TOKEN
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL) && authClient != null && authClient.getWebAuthenticationDetails() != null) {
+                data.put("webAuthenticationDetails", authClient.getWebAuthenticationDetails());
+            }
+
+            // CLIENT DATA
+            if (authClient != null) {
+                Map<String, Object> clientData = AuditHelperMethods.clientData(authClient, realm);
+                data.put("client", clientData);
+            }
+
+            // USER DATA
+            if (rawAuthentication != null && rawAuthentication.getDetails() != null) {
+                Map<String, Object> userData = AuditHelperMethods.userData(rawAuthentication.getDetails(), levelRealmEvent);
+                data.put("user", userData);
+            }
+
+            // TOKEN TYPE
+            String tokenType = AuditHelperMethods.tokenType(token, rawAuthentication);
+            data.put("type", tokenType);
+
+            // TOKEN VALUE SANITIZE
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL)) {
+                String safeTokenValue = AuditHelperMethods.sanitizeToken(token.getValue());
+                data.put("token", safeTokenValue);
+            }
             data.put("scope", token.getScope());
 
             data.put("jti", token.getToken());

--- a/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java
@@ -1,0 +1,206 @@
+package it.smartcommunitylab.aac.audit.helper;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import it.smartcommunitylab.aac.Config;
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.model.Realm;
+import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
+import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
+import it.smartcommunitylab.aac.oauth.event.TokenGrantEvent;
+import it.smartcommunitylab.aac.oauth.model.AuthorizationGrantType;
+import it.smartcommunitylab.aac.oauth.model.OAuth2ClientDetails;
+import it.smartcommunitylab.aac.realms.service.RealmService;
+import org.springframework.security.core.Authentication;
+import org.springframework.util.StringUtils;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public class AuditHelperMethods {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    // PREPARE CLIENT DATA
+    public static Map<String, Object> clientData(OAuth2ClientAuthenticationToken authClient, String realm){
+        Map<String, Object> clientData = new LinkedHashMap<>();
+        OAuth2ClientDetails clientDetails = authClient.getOAuth2ClientDetails();
+
+        clientData.put("clientId", authClient.getClientId());
+        clientData.put("realm", clientDetails != null ? clientDetails.getRealm() : realm);
+        clientData.put("clientName", clientDetails != null ? clientDetails.getName() : authClient.getName());
+
+        return clientData;
+    }
+
+    // PREPARE USER DATA
+    public static Map<String, Object> userData(Object rawAuthenticationDetails, String levelRealmEvent) {
+        switch (levelRealmEvent) {
+            case SystemKeys.EVENTS_LEVEL_MINIMAL: {
+                return extractMinimalUserData(rawAuthenticationDetails);
+            }
+            case SystemKeys.EVENTS_LEVEL_DETAILS: {
+                Map<String, Object> userData = extractMinimalUserData(rawAuthenticationDetails);
+                Map<String, Object> safeUserDetails = AuditHelperMethods.extractUserDetails(rawAuthenticationDetails);
+                userData.put("details", safeUserDetails);
+                return userData;
+            }
+            case SystemKeys.EVENTS_LEVEL_FULL: {
+                return MAPPER.convertValue(rawAuthenticationDetails, new TypeReference<>() {});
+            }
+        }
+        return Map.of();
+    }
+
+    // Extracts the minimal fields (subjectId, realm, username)
+    private static Map<String, Object> extractMinimalUserData(Object rawAuthenticationDetails) {
+        Map<String, Object> userData = new LinkedHashMap<>();
+        Map<String, Object> authUserMap = MAPPER.convertValue(rawAuthenticationDetails, new TypeReference<>() {});
+
+        userData.put("subjectId", authUserMap.get("subjectId"));
+        userData.put("realm", authUserMap.get("realm"));
+        userData.put("username", authUserMap.get("username"));
+
+        return userData;
+    }
+
+    // PREPARE TOKEN SANITIZE
+    public static String sanitizeToken(String tokenValue) {
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            return tokenValue;
+        }
+
+        int firstDot = tokenValue.indexOf('.');
+
+        if (firstDot != -1) {
+            int secondDot = tokenValue.indexOf('.', firstDot + 1);
+
+            // Ensure exactly two dots for a valid JWT format
+            if (secondDot != -1 && tokenValue.indexOf('.', secondDot + 1) == -1) {
+                return tokenValue.substring(0, secondDot + 1) + "__SIGNATURE__";
+            }
+        }
+
+        // Fallback for non-JWT formats
+        return "***MASKED_TOKEN***";
+    }
+
+    // PREPARE ISSUED TOKEN
+    public static List<String> issuedTokens(AACOAuth2AccessToken token, TokenGrantEvent event) {
+        List<String> issuedTokens = new ArrayList<>();
+
+        if (token == null) {
+            return issuedTokens;
+        }
+
+        // Defensively check if the access token value is actually present
+        if (token.getValue() != null && !token.getValue().isEmpty()) {
+            issuedTokens.add("access_token");
+        }
+
+        // Check if a refresh token was issued
+        if (token.getRefreshToken() != null && token.getRefreshToken().getValue() != null) {
+            issuedTokens.add("refresh_token");
+        }
+
+        // NOTE: At this point token.getIdToken() is usually null.
+        // The OIDCTokenEnhancer that would normally populate it is disabled in OAuth2Config.
+        // The real id_token is actually built later in TokenEndpoint (via idTokenServices.createIdToken),
+        // AFTER this audit event is already published.
+        //
+        // To keep the "issued_tokens" array accurate, we mirror the exact issuing rules of TokenEndpoint:
+        // an id_token is generated only for user-centric grants (authorization_code, refresh_token,
+        // implicit, and password) provided the "openid" scope is requested. Machine-to-machine grants
+        // (like client_credentials) never issue an id_token and are excluded.
+        //
+        // We keep the defensive token.getIdToken() != null check as a fallback in case
+        // the OIDCTokenEnhancer is ever re-enabled in the system configuration.
+        boolean isEligibleGrantType =
+            AuthorizationGrantType.AUTHORIZATION_CODE.getValue().equals(event.getGrantType()) ||
+            AuthorizationGrantType.REFRESH_TOKEN.getValue().equals(event.getGrantType()) ||
+            AuthorizationGrantType.IMPLICIT.getValue().equals(event.getGrantType()) ||
+            AuthorizationGrantType.PASSWORD.getValue().equals(event.getGrantType());
+
+        boolean idTokenIssued = isEligibleGrantType &&
+            token.getScope() != null &&
+            token.getScope().contains(Config.SCOPE_OPENID);
+
+        if (token.getIdToken() != null || idTokenIssued) {
+            issuedTokens.add("id_token");
+        }
+
+        return issuedTokens;
+    }
+
+    // PREPARE TOKEN TYPE
+    public static String tokenType(AACOAuth2AccessToken token, Authentication rawAuthentication){
+        // determine token type from the token itself: on refresh grants the
+        // OAuth2Authentication carried by the event has no userAuthentication,
+        // so we must rely on the token subject vs authorizedParty (client_id)
+        String subject = token.getSubject();
+        boolean isUserToken =
+            rawAuthentication != null ||
+                (StringUtils.hasText(subject) && !subject.equals(token.getAuthorizedParty()));
+        return isUserToken ? "user" : "client";
+    }
+
+    // RESOLVE AUDIT-OAUTH2TOKEN-LEVEL CONFIGURED IN REALM
+    public static String resolveOauth2EventsLevel(RealmService realmService, String realm) {
+        if (realmService != null && StringUtils.hasText(realm)) {
+            Realm r = realmService.findRealm(realm);
+            if (
+                r != null &&
+                    r.getAuditConfiguration() != null &&
+                    StringUtils.hasText(r.getAuditConfiguration().getOauth2EventsLevel())
+            ) {
+                return r.getAuditConfiguration().getOauth2EventsLevel();
+            }
+        }
+
+        // DEFAULT VALUE
+        return SystemKeys.EVENTS_LEVEL_NONE;
+    }
+
+    public static Map<String, Object> extractUserDetails(Object rawDetails) {
+        try {
+            if (rawDetails == null) {
+                return null;
+            }
+
+            Map<String, Object> safeDetails = new LinkedHashMap<>();
+
+            // Jackson converts to LinkedHashMap, preserving original JSON order
+            Map<String, Object> mappedObject = MAPPER.convertValue(rawDetails, new TypeReference<>() {});
+
+            Object identitiesObj = mappedObject.get("identities");
+
+            if (identitiesObj instanceof List) {
+                List<Map<String, Object>> rawIdentities = MAPPER.convertValue(identitiesObj, new TypeReference<>() {});
+                List<Map<String, Object>> safeIdentities = new ArrayList<>();
+
+                // Iterate over ALL identities
+                for (Map<String, Object> rawIdentity : rawIdentities) {
+                    if (!rawIdentity.containsKey("principal")) {
+                        continue;
+                    }
+                    Map<String, Object> safeIdentity = new LinkedHashMap<>();
+
+                    // Extract exclusively the "account" block if present
+                    if (rawIdentity.containsKey("account")) {
+                        Object accountObj = rawIdentity.get("account");
+                        Map<String, Object> safeAccount = MAPPER.convertValue(accountObj, new TypeReference<>() {});
+                        safeIdentity.put("account", safeAccount);
+                        safeIdentities.add(safeIdentity);
+                    }
+                }
+                safeDetails.put("identities", safeIdentities);
+            }
+            return safeDetails;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error converting details object properties: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/audit/model/AuditConfigurationMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/model/AuditConfigurationMap.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.smartcommunitylab.aac.audit.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import it.smartcommunitylab.aac.core.model.ConfigurableProperties;
+
+import javax.validation.Valid;
+import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
+
+/*
+ * Realm level audit configuration.
+ * Holds the events detail level for the OAuth2 token grant audit context
+ * (OAUTH2_TOKEN_GRANT), configurable per realm.
+ */
+
+@Valid
+@JsonInclude(Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class AuditConfigurationMap implements ConfigurableProperties {
+
+    private static ObjectMapper mapper = new ObjectMapper();
+    private static final TypeReference<HashMap<String, Serializable>> typeRef =
+        new TypeReference<HashMap<String, Serializable>>() {};
+
+    // detail level for the OAuth2 token grant audit events
+    // when null, the listener keeps the default (full) behaviour
+    private String oauth2EventsLevel;
+
+    public AuditConfigurationMap() {}
+
+    public String getOauth2EventsLevel() {
+        return oauth2EventsLevel;
+    }
+
+    public void setOauth2EventsLevel(String oauth2EventsLevel) {
+        this.oauth2EventsLevel = oauth2EventsLevel;
+    }
+
+    @Override
+    @JsonIgnore
+    public Map<String, Serializable> getConfiguration() {
+        // use mapper
+        mapper.setSerializationInclusion(Include.NON_EMPTY);
+        return mapper.convertValue(this, typeRef);
+    }
+
+    @Override
+    @JsonIgnore
+    public void setConfiguration(Map<String, Serializable> props) {
+        // use mapper
+        mapper.setSerializationInclusion(Include.NON_EMPTY);
+        AuditConfigurationMap map = mapper.convertValue(props, AuditConfigurationMap.class);
+
+        this.oauth2EventsLevel = map.getOauth2EventsLevel();
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/bootstrap/AACBootstrap.java
+++ b/src/main/java/it/smartcommunitylab/aac/bootstrap/AACBootstrap.java
@@ -454,7 +454,8 @@ public class AACBootstrap {
                                 : null,
                             r.getTemplatesConfiguration() != null
                                 ? r.getTemplatesConfiguration().getConfiguration()
-                                : null
+                                : null,
+                            r.getAuditConfiguration() != null ? r.getAuditConfiguration().getConfiguration() : null
                         );
                     }
 

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -37,6 +37,7 @@ import it.smartcommunitylab.aac.oauth.provider.ClientRegistrationServices;
 import it.smartcommunitylab.aac.oauth.request.ExtRedirectResolver;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientRegistrationServices;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientService;
 import it.smartcommunitylab.aac.oauth.store.AuthorizationRequestStore;
 import it.smartcommunitylab.aac.oauth.store.ExtTokenStore;
@@ -321,7 +322,8 @@ public class OAuth2Config {
         ScopeRegistry scopeRegistry,
         UserService userService,
         FlowExtensionsService flowExtensionsService,
-        OAuth2EventPublisher oauth2EventPublisher
+        OAuth2EventPublisher oauth2EventPublisher,
+        ExtTokenStore tokenStore
     ) {
         // build our own list of granters
         List<AbstractTokenGranter> granters = new ArrayList<>();
@@ -357,6 +359,7 @@ public class OAuth2Config {
             oAuth2RequestFactory
         );
         refreshTokenGranter.setEventPublisher(oauth2EventPublisher);
+        refreshTokenGranter.setTokenStore(tokenStore);
         granters.add(refreshTokenGranter);
 
         // implicit
@@ -448,7 +451,12 @@ public class OAuth2Config {
     }
 
     @Bean
-    public OAuth2EventListener oauth2EventListener(OAuth2ClientDetailsService clientDetailsService) {
-        return new OAuth2EventListener(clientDetailsService);
+    public OAuth2EventListener oauth2EventListener(
+            OAuth2ClientDetailsService clientDetailsService,
+            RealmService realmService
+    ) {
+        OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
+        listener.setRealmService(realmService);
+        return listener;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/model/Realm.java
+++ b/src/main/java/it/smartcommunitylab/aac/model/Realm.java
@@ -19,6 +19,7 @@ package it.smartcommunitylab.aac.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import it.smartcommunitylab.aac.audit.model.AuditConfigurationMap;
 import it.smartcommunitylab.aac.oauth.model.OAuth2ConfigurationMap;
 import it.smartcommunitylab.aac.templates.model.LocalizationConfigurationMap;
 import it.smartcommunitylab.aac.templates.model.TemplatesConfigurationMap;
@@ -47,12 +48,14 @@ public class Realm {
     private TosConfigurationMap tosConfiguration;
     private LocalizationConfigurationMap localizationConfiguration;
     private TemplatesConfigurationMap templatesConfiguration;
+    private AuditConfigurationMap auditConfiguration;
 
     public Realm() {
         this.oauthConfiguration = new OAuth2ConfigurationMap();
         this.tosConfiguration = new TosConfigurationMap();
         this.localizationConfiguration = new LocalizationConfigurationMap();
         this.templatesConfiguration = new TemplatesConfigurationMap();
+        this.auditConfiguration = new AuditConfigurationMap();
     }
 
     public Realm(String slug) {
@@ -61,6 +64,7 @@ public class Realm {
         this.tosConfiguration = new TosConfigurationMap();
         this.localizationConfiguration = new LocalizationConfigurationMap();
         this.templatesConfiguration = new TemplatesConfigurationMap();
+        this.auditConfiguration = new AuditConfigurationMap();
     }
 
     public String getName() {
@@ -139,11 +143,20 @@ public class Realm {
         this.templatesConfiguration = templatesConfiguration;
     }
 
+    public AuditConfigurationMap getAuditConfiguration() {
+        return auditConfiguration;
+    }
+
+    public void setAuditConfiguration(AuditConfigurationMap auditConfiguration) {
+        this.auditConfiguration = auditConfiguration;
+    }
+
     public void clearConfig() {
         this.oauthConfiguration= null;
         this.tosConfiguration= null;
         this.localizationConfiguration= null;
         this.templatesConfiguration= null;
+        this.auditConfiguration= null;
     }
     
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/event/OAuth2EventPublisher.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/event/OAuth2EventPublisher.java
@@ -47,8 +47,17 @@ public class OAuth2EventPublisher implements ApplicationEventPublisherAware {
     }
 
     public void publishTokenGrant(OAuth2AccessToken token, OAuth2Authentication authentication, OAuth2ClientAuthenticationToken clientAuth) {
+        publishTokenGrant(token, authentication, clientAuth, null);
+    }
+
+    public void publishTokenGrant(
+        OAuth2AccessToken token,
+        OAuth2Authentication authentication,
+        OAuth2ClientAuthenticationToken clientAuth,
+        String grantType
+    ) {
         if (this.applicationEventPublisher != null) {
-            this.applicationEventPublisher.publishEvent(new TokenGrantEvent(token, authentication, clientAuth));
+            this.applicationEventPublisher.publishEvent(new TokenGrantEvent(token, authentication, clientAuth, grantType));
         }
     }
 

--- a/src/main/java/it/smartcommunitylab/aac/oauth/event/TokenGrantEvent.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/event/TokenGrantEvent.java
@@ -30,12 +30,25 @@ public class TokenGrantEvent extends OAuth2Event {
     private final OAuth2Authentication authentication;
     private final OAuth2ClientAuthenticationToken clientAuth;
 
+    // the grant type that produced this token (e.g. authorization_code, refresh_token)
+    private final String grantType;
+
     public TokenGrantEvent(OAuth2AccessToken token, OAuth2Authentication authentication, OAuth2ClientAuthenticationToken clientAuth) {
+        this(token, authentication, clientAuth, null);
+    }
+
+    public TokenGrantEvent(
+            OAuth2AccessToken token,
+            OAuth2Authentication authentication,
+            OAuth2ClientAuthenticationToken clientAuth,
+            String grantType
+    ) {
         super(authentication.getOAuth2Request());
         Assert.notNull(token, "token can not be null");
         this.token = token;
         this.authentication = authentication;
         this.clientAuth = clientAuth;
+        this.grantType = grantType;
     }
 
     public OAuth2AccessToken getToken() {
@@ -48,5 +61,9 @@ public class TokenGrantEvent extends OAuth2Event {
 
     public OAuth2ClientAuthenticationToken getClientAuthentication() {
         return clientAuth;
+    }
+
+    public String getGrantType() {
+        return grantType;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/token/AbstractTokenGranter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/token/AbstractTokenGranter.java
@@ -91,7 +91,7 @@ public abstract class AbstractTokenGranter implements TokenGranter {
 
         // audit
         if (eventPublisher != null) {
-            eventPublisher.publishTokenGrant(accessToken, authentication, clientAuth);
+            eventPublisher.publishTokenGrant(accessToken, authentication, clientAuth, grantType);
         }
 
         // check extensions

--- a/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
@@ -18,9 +18,11 @@ package it.smartcommunitylab.aac.oauth.token;
 
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
+import it.smartcommunitylab.aac.oauth.store.ExtTokenStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
@@ -32,6 +34,10 @@ public class RefreshTokenGranter extends AbstractTokenGranter {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final String GRANT_TYPE = "refresh_token";
+
+    // optional token store, used to recover the full original authentication
+    // (including the end-user) for audit events during the refresh flow
+    private ExtTokenStore tokenStore;
 
     public RefreshTokenGranter(
         AuthorizationServerTokenServices tokenServices,
@@ -74,5 +80,38 @@ public class RefreshTokenGranter extends AbstractTokenGranter {
         String refreshToken = tokenRequest.getRequestParameters().get("refresh_token");
         logger.trace("get access token for refresh token " + refreshToken);
         return getTokenServices().refreshAccessToken(refreshToken, tokenRequest);
+    }
+
+    /*
+     * Recover the full original authentication (including the end-user) bound to the
+     * refresh token. The base implementation builds a client-only authentication with
+     * a null user, which would strip the end-user context from audit events fired for
+     * the refresh_token grant. Falls back to the base behaviour if the authentication
+     * cannot be recovered.
+     */
+    @Override
+    protected OAuth2Authentication getOAuth2Authentication(ClientDetails client, TokenRequest tokenRequest) {
+        if (tokenStore != null) {
+            try {
+                String refreshTokenValue = tokenRequest.getRequestParameters().get("refresh_token");
+                if (refreshTokenValue != null) {
+                    OAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
+                    if (refreshToken != null) {
+                        OAuth2Authentication authentication = tokenStore.readAuthenticationForRefreshToken(refreshToken);
+                        if (authentication != null && authentication.getUserAuthentication() != null) {
+                            return authentication;
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("unable to recover full authentication for refresh token audit event: " + e.getMessage());
+            }
+        }
+
+        return super.getOAuth2Authentication(client, tokenRequest);
+    }
+
+    public void setTokenStore(ExtTokenStore tokenStore) {
+        this.tokenStore = tokenStore;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/realms/RealmManager.java
+++ b/src/main/java/it/smartcommunitylab/aac/realms/RealmManager.java
@@ -277,6 +277,11 @@ public class RealmManager {
             templatesConfigMap = r.getTemplatesConfiguration().getConfiguration();
         }
 
+        Map<String, Serializable> auditConfigMap = null;
+        if (r.getAuditConfiguration() != null) {
+            auditConfigMap = r.getAuditConfiguration().getConfiguration();
+        }
+
         Realm realm = realmService.updateRealm(
             slug,
             name,
@@ -286,7 +291,8 @@ public class RealmManager {
             oauth2ConfigMap,
             tosConfigMap,
             localizationConfigMap,
-            templatesConfigMap
+            templatesConfigMap,
+            auditConfigMap
         );
 
         return realm;

--- a/src/main/java/it/smartcommunitylab/aac/realms/persistence/RealmEntity.java
+++ b/src/main/java/it/smartcommunitylab/aac/realms/persistence/RealmEntity.java
@@ -88,6 +88,11 @@ public class RealmEntity {
     @Convert(converter = HashMapConverter.class)
     private Map<String, Serializable> templatesConfigurationMap;    
 
+    @Lob
+    @Column(name = "audit_configuration_map")
+    @Convert(converter = HashMapConverter.class)
+    private Map<String, Serializable> auditConfigurationMap;
+
     public String getName() {
         return name;
     }
@@ -175,5 +180,13 @@ public class RealmEntity {
     public void setTemplatesConfigurationMap(Map<String, Serializable> templatesConfigurationMap) {
         this.templatesConfigurationMap = templatesConfigurationMap;
     }
-    
+
+    public Map<String, Serializable> getAuditConfigurationMap() {
+        return auditConfigurationMap;
+    }
+
+    public void setAuditConfigurationMap(Map<String, Serializable> auditConfigurationMap) {
+        this.auditConfigurationMap = auditConfigurationMap;
+    }
+
 }

--- a/src/main/java/it/smartcommunitylab/aac/realms/service/RealmService.java
+++ b/src/main/java/it/smartcommunitylab/aac/realms/service/RealmService.java
@@ -19,6 +19,7 @@ package it.smartcommunitylab.aac.realms.service;
 import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.common.AlreadyRegisteredException;
 import it.smartcommunitylab.aac.common.InvalidDataException;
+import it.smartcommunitylab.aac.audit.model.AuditConfigurationMap;
 import it.smartcommunitylab.aac.common.NoSuchRealmException;
 import it.smartcommunitylab.aac.common.RegistrationException;
 import it.smartcommunitylab.aac.model.Realm;
@@ -161,7 +162,8 @@ public class RealmService implements InitializingBean {
         Map<String, Serializable> oauthConfigurationMap,
         Map<String, Serializable> tosConfigurationMap,
         Map<String, Serializable> locConfigurationMap,
-        Map<String, Serializable> templatesConfigurationMap
+        Map<String, Serializable> templatesConfigurationMap,
+        Map<String, Serializable> auditConfigurationMap
     ) throws NoSuchRealmException {
         if (SystemKeys.REALM_GLOBAL.equals(slug) || SystemKeys.REALM_SYSTEM.equals(slug)) {
             throw new IllegalArgumentException("system realms are immutable");
@@ -181,6 +183,7 @@ public class RealmService implements InitializingBean {
         r.setTosConfigurationMap(tosConfigurationMap);
         r.setLocalizationConfigurationMap(locConfigurationMap);
         r.setTemplatesConfigurationMap(templatesConfigurationMap);
+        r.setAuditConfigurationMap(auditConfigurationMap);
 
         r = realmRepository.save(r);
 
@@ -299,6 +302,12 @@ public class RealmService implements InitializingBean {
             templatesConfigMap.setConfiguration(re.getTemplatesConfigurationMap());
         }
         r.setTemplatesConfiguration(templatesConfigMap);
+
+        AuditConfigurationMap auditConfigMap = new AuditConfigurationMap();
+        if (re.getAuditConfigurationMap() != null) {
+            auditConfigMap.setConfiguration(re.getAuditConfigurationMap());
+        }
+        r.setAuditConfiguration(auditConfigMap);
 
         return r;
     }

--- a/src/test/java/it/smartcommunitylab/aac/tos/TosConfigTest.java
+++ b/src/test/java/it/smartcommunitylab/aac/tos/TosConfigTest.java
@@ -96,7 +96,8 @@ public class TosConfigTest {
             realm.getOAuthConfiguration().getConfiguration(),
             tosConfig.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
 
         //updated model shows 'enabled'
@@ -122,7 +123,8 @@ public class TosConfigTest {
             realm.getOAuthConfiguration().getConfiguration(),
             tosConfig.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
 
         //updated model shows 'disabled'
@@ -163,7 +165,8 @@ public class TosConfigTest {
             realm.getOAuthConfiguration().getConfiguration(),
             tosConfig.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
 
         //updated model shows 'enabled'
@@ -189,7 +192,8 @@ public class TosConfigTest {
             realm.getOAuthConfiguration().getConfiguration(),
             tosConfig.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
 
         //updated model shows 'disabled'
@@ -264,7 +268,8 @@ public class TosConfigTest {
             realm.getOAuthConfiguration().getConfiguration(),
             configMap.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
     }
 

--- a/src/test/java/it/smartcommunitylab/aac/tos/TosUserTest.java
+++ b/src/test/java/it/smartcommunitylab/aac/tos/TosUserTest.java
@@ -263,7 +263,8 @@ public class TosUserTest {
             realm.getOAuthConfiguration().getConfiguration(),
             configMap.getConfiguration(),
             realm.getLocalizationConfiguration().getConfiguration(),
-            realm.getTemplatesConfiguration().getConfiguration()
+            realm.getTemplatesConfiguration().getConfiguration(),
+            realm.getAuditConfiguration().getConfiguration()
         );
     }
 


### PR DESCRIPTION
This PR unifies multiple interdependent issues to centralize, secure, and make the audit log tracking (TokenGrantEvent) configurable.
It introduces the new audit level feature within the Realm for all token types, leveraging the new AuditHelperMethods utility, and extends the TokenGranter classes to preserve the execution context.

Main Changes Mapping:

1. Dynamic Audit Level Configuration (Closes #800)
Allows configuring the log verbosity directly from the UI for each individual Realm (levels: NONE, MINIMAL, DETAILS, FULL). These are incremental based on the required level of detail.

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java#L39-L56

Backend: Extended RealmEntity with auditConfigurationMap. Introduced AuditHelperMethods.resolveOauth2EventsLevel() to resolve the level with a secure fallback to NONE.

Frontend (React): Added a new "Audit" tab in the RealmEdit component, integrated with realmAuditSchema to select the level via a dropdown menu, where it specifies that the default level is NONE (resulting in no logs).

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/dev-console/src/i18n/en/fields.json#L277-L280

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/dev-console/src/myrealms/schemas.ts#L63-L73

2. User Context Recovery in Refresh Grants
Fixes the loss of user data during refresh flows. Since standard refresh grants lose the user's authentication payload, RefreshTokenGranter has been modified to use ExtTokenStore: it now traces back to the refresh_token to recover the complete, original OAuth2Authentication. This ensures that the audit log retains the user data and correctly identifies the token type ("user" vs "client").

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java#L85-L112

AuditHelperMethods Filters Mapping:

1. Dynamic User Payload Filtering (Closes #800)
Solves the log bloat problem. Based on the configured level, AuditHelperMethods.userData() filters and extracts the user payload according to the required detail. It discards heavy arrays (e.g., attributeSets) and keeps only essential data (or omits them entirely in MINIMAL mode). For the DETAILS level, it extracts from userDetails() (which is used for FULL) only the accounts within the identities where the principal element is present.

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java#L184-L198

2. Explicit Grant Type and Issued Tokens Tracking
AbstractTokenGranter and OAuth2EventPublisher have been updated to explicitly propagate the grantType within the TokenGrantEvent. This allows the helper to accurately calculate the issued_tokens array (deducing the id_token emission based on the grant type and the openid scope).

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/oauth/token/AbstractTokenGranter.java#L92-L95

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/oauth/event/TokenGrantEvent.java#L40-L52

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java#L99-L133

3. Token Sanitization for Security & Compliance (Closes #805)
Aligns with GDPR, AGID guidelines, and RFC 6749/9068 to prevent replay attacks. AuditHelperMethods.sanitizeToken() programmatically replaces JWT signatures with the __SIGNATURE__ string, and fully masks non-JWT tokens (returning ***MASKED_TOKEN***), representing the only data modification related to tokens. The token saved at rest becomes unusable for external APIs.

https://github.com/scc-digitalhub/AAC/blob/0b3b0a6f239de9699faa7746efeb03147689ebcc/src/main/java/it/smartcommunitylab/aac/audit/helper/AuditHelperMethods.java#L76-L88