### PR TITLE
fix: update username validation pattern in OAuth2RequestFactory

### DIFF
--- a/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
@@ -186,7 +186,7 @@ public class OAuth2RequestFactory
                 throw new UnsupportedGrantTypeException("Grant type not supported: " + grantType);
             }
             if (authorizationGrantType == PASSWORD) {
-                String username = readParameter(requestParameters, "username", EMAIL_PATTERN);
+                String username = readParameter(requestParameters, "username", USERNAME_PATTERN);
                 String password = requestParameters.get("password");
                 Set<String> requestScopes = extractScopes(scopes, clientDetails.getScope(), false);
 
@@ -683,8 +683,10 @@ public class OAuth2RequestFactory
 
     public static final String SLUG_PATTERN = SystemKeys.SLUG_PATTERN;
     public static final String STRING_PATTERN = "^[a-zA-Z0-9_:-]+$";
+    // Pattern for validating user identifiers.
+    // Accepts either a simple username or a fully-qualified email address.
     // Reference: https://www.rfc-editor.org/info/rfc5322/#section-3.2.3
-    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
+    public static final String USERNAME_PATTERN = "^[a-zA-Z0-9._%+-]+(@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})?$";
     public static final String URI_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String SPECIAL_PATTERN = "^[a-zA-Z0-9_!=@$&%():/\\-`.+,/\"]*$";
     public static final String SPACE_STRING_PATTERN = "^[a-zA-Z0-9 _:-]+$";

--- a/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/request/OAuth2RequestFactory.java
@@ -683,10 +683,9 @@ public class OAuth2RequestFactory
 
     public static final String SLUG_PATTERN = SystemKeys.SLUG_PATTERN;
     public static final String STRING_PATTERN = "^[a-zA-Z0-9_:-]+$";
-    // Pattern for validating user identifiers.
-    // Accepts either a simple username or a fully-qualified email address.
+    public static final String USERNAME_PATTERN = "^[a-zA-Z0-9_.+@%!-]+$";
     // Reference: https://www.rfc-editor.org/info/rfc5322/#section-3.2.3
-    public static final String USERNAME_PATTERN = "^[a-zA-Z0-9._%+-]+(@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,})?$";
+    public static final String EMAIL_PATTERN = "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$";
     public static final String URI_PATTERN = "^[a-zA-Z0-9._:/-]+$";
     public static final String SPECIAL_PATTERN = "^[a-zA-Z0-9_!=@$&%():/\\-`.+,/\"]*$";
     public static final String SPACE_STRING_PATTERN = "^[a-zA-Z0-9 _:-]+$";


### PR DESCRIPTION
### Description
Fixes unit test failures in `ResourceOwnerPasswordGrantTest` caused by strict email pattern validation on the `username` parameter during `PASSWORD` grant requests.

### Root Cause
Following the changes in #792, `OAuth2RequestFactory` was enforcing `EMAIL_PATTERN`, which rejected plain usernames (such as `"test"` used in test configurations) with an `IllegalArgumentException` before reaching the authentication logic.

### Solution
- Introduced `USERNAME_PATTERN` to support both plain string usernames and fully-qualified email addresses.
- Updated `OAuth2RequestFactory` to validate the `username` parameter using `USERNAME_PATTERN` for `PASSWORD` grant requests.

Fixes #812
Ref #792