### PR TITLE
feat(audit): [Part 1/3] Add dynamic OAuth2 audit level configuration (UI & Core)

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -342,6 +342,10 @@
         "tokenType": {
             "helperText": "",
             "name": "Token type"
+        },
+        "eventsLevel": {
+            "helperText": "Detail level for OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT) in this realm. Leave empty to keep the default (none).",
+            "name": "OAuth2 token events level"
         }
     },
     "persistence": {

--- a/dev-console/src/myrealms/schemas.ts
+++ b/dev-console/src/myrealms/schemas.ts
@@ -42,6 +42,12 @@ export const realmOAuthSchema: RJSFSchema = {
             title: 'field.oauth2.openClientRegistration.name',
             description: 'field.oauth2.openClientRegistration.helperText',
         },
+        eventsLevel: {
+            type: 'string',
+            enum: ['none', 'minimal', 'details', 'full'],
+            title: 'field.oauth2.eventsLevel.name',
+            description: 'field.oauth2.eventsLevel.helperText',
+        },
     },
 };
 export const realmTosSchema: RJSFSchema = {

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,6 +16,8 @@
 
 package it.smartcommunitylab.aac.audit;
 
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.model.Realm;
 import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.event.OAuth2AuthorizationExceptionEvent;
@@ -28,6 +30,8 @@ import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -52,6 +56,12 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
     private ApplicationEventPublisher publisher;
 
     private final OAuth2ClientDetailsService clientService;
+
+    private RealmService realmService;
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
+    }
 
     public OAuth2EventListener(OAuth2ClientDetailsService clientService) {
         Assert.notNull(clientService, "client service is required");
@@ -158,6 +168,12 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
             String realm = token.getRealm();
             String type = auth.getUserAuthentication() == null ? "client" : "user";
 
+            String levelRealmEvent = resolveOauth2EventsLevel(realm);
+
+            if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_NONE)) {
+                return;
+            }
+
             Map<String, Object> data = new HashMap<>();
             Map<String, Object> webAuthenticationDetails = new HashMap<>();
 
@@ -200,5 +216,16 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
         if (getPublisher() != null) {
             getPublisher().publishEvent(new AuditApplicationEvent(event));
         }
+    }
+
+    private String resolveOauth2EventsLevel(String realm) {
+        if (realmService == null || !StringUtils.hasText(realm)) {
+            return SystemKeys.EVENTS_LEVEL_NONE;
+        }
+        Realm r = realmService.findRealm(realm);
+        String level = (r != null && r.getOAuthConfiguration() != null)
+            ? r.getOAuthConfiguration().getEventsLevel()
+            : null;
+        return StringUtils.hasText(level) ? level : SystemKeys.EVENTS_LEVEL_NONE;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -58,6 +58,7 @@ import it.smartcommunitylab.aac.oauth.token.ResourceOwnerPasswordTokenGranter;
 import it.smartcommunitylab.aac.openid.service.OIDCTokenServices;
 import it.smartcommunitylab.aac.openid.token.IdTokenServices;
 import it.smartcommunitylab.aac.profiles.claims.OpenIdClaimsExtractorProvider;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import it.smartcommunitylab.aac.scope.ScopeRegistry;
 import it.smartcommunitylab.aac.users.service.UserService;
 import java.beans.PropertyVetoException;
@@ -448,7 +449,12 @@ public class OAuth2Config {
     }
 
     @Bean
-    public OAuth2EventListener oauth2EventListener(OAuth2ClientDetailsService clientDetailsService) {
-        return new OAuth2EventListener(clientDetailsService);
+    public OAuth2EventListener oauth2EventListener(
+        OAuth2ClientDetailsService clientDetailsService,
+        RealmService realmService
+    ) {
+        OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
+        listener.setRealmService(realmService);
+        return listener;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.core.model.ConfigurableProperties;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -39,6 +40,10 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
     private Boolean enableClientRegistration;
     private Boolean openClientRegistration;
+
+    // detail level for the OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT)
+    // defaults to none; the listener keeps the default behaviour when not configured
+    private String eventsLevel = SystemKeys.EVENTS_LEVEL_NONE;
 
     public OAuth2ConfigurationMap() {
         enableClientRegistration = false;
@@ -69,6 +74,14 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
         this.openClientRegistration = openClientRegistration;
     }
 
+    public String getEventsLevel() {
+        return eventsLevel;
+    }
+
+    public void setEventsLevel(String eventsLevel) {
+        this.eventsLevel = eventsLevel;
+    }
+
     @Override
     @JsonIgnore
     public Map<String, Serializable> getConfiguration() {
@@ -86,5 +99,6 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
         this.enableClientRegistration = map.getEnableClientRegistration();
         this.openClientRegistration = map.getOpenClientRegistration();
+        this.eventsLevel = map.getEventsLevel();
     }
 }


### PR DESCRIPTION
*This PR is part 1 of a 3-part series aiming to centralize, secure, and make audit log tracking configurable.*

### What this PR does
It introduces the core configuration layer to allow administrators to dynamically set the OAuth2 audit log verbosity directly from the UI for each individual Realm, #800.

*   **Backend:** Updates `OAuth2ConfigurationMap` and `OAuth2Config` to store the new audit configuration. In `OAuth2EventListener`, it introduces the `resolveOauth2EventsLevel()` method leveraging `RealmService` to read the configuration, gracefully defaulting to `NONE`.
*   **Frontend (React):** Exposes a dropdown menu with 4 incremental levels: `none`, `minimal`, `details`, and `full` in the Realm configuration.

### Next steps
* Part 2 will implement the actual user payload filtering logic and token sanitization within the `OAuth2EventListener`.
* Part 3 will address user context recovery in refresh tokens.