### PR TITLE
feat(audit): [Part 2/3] Implement dynamic payload filtering and token sanitization

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -342,6 +342,10 @@
         "tokenType": {
             "helperText": "",
             "name": "Token type"
+        },
+        "eventsLevel": {
+            "helperText": "Detail level for OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT) in this realm. Leave empty to keep the default (none).",
+            "name": "OAuth2 token events level"
         }
     },
     "persistence": {

--- a/dev-console/src/myrealms/schemas.ts
+++ b/dev-console/src/myrealms/schemas.ts
@@ -42,6 +42,12 @@ export const realmOAuthSchema: RJSFSchema = {
             title: 'field.oauth2.openClientRegistration.name',
             description: 'field.oauth2.openClientRegistration.helperText',
         },
+        eventsLevel: {
+            type: 'string',
+            enum: ['none', 'minimal', 'details', 'full'],
+            title: 'field.oauth2.eventsLevel.name',
+            description: 'field.oauth2.eventsLevel.helperText',
+        },
     },
 };
 export const realmTosSchema: RJSFSchema = {

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,6 +16,11 @@
 
 package it.smartcommunitylab.aac.audit;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.model.Realm;
 import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.event.OAuth2AuthorizationExceptionEvent;
@@ -27,7 +32,11 @@ import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -45,6 +54,8 @@ import org.springframework.util.StringUtils;
 
 public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, ApplicationEventPublisherAware {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public static final String TOKEN_GRANT = "OAUTH2_TOKEN_GRANT";
@@ -52,6 +63,12 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
     private ApplicationEventPublisher publisher;
 
     private final OAuth2ClientDetailsService clientService;
+
+    private RealmService realmService;
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
+    }
 
     public OAuth2EventListener(OAuth2ClientDetailsService clientService) {
         Assert.notNull(clientService, "client service is required");
@@ -149,30 +166,68 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
             OAuth2ClientAuthenticationToken authClient = event.getClientAuthentication();
             Authentication authUser = auth.getUserAuthentication();
 
-            //            String principal = auth.getName();
             String principal = token.getSubject();
             if (!StringUtils.hasText(principal)) {
                 principal = auth.getName();
             }
 
             String realm = token.getRealm();
-            String type = auth.getUserAuthentication() == null ? "client" : "user";
+            // realm level detail configuration
+            String levelRealmEvent = resolveOauth2EventsLevel(realm);
 
-            Map<String, Object> data = new HashMap<>();
-            Map<String, Object> webAuthenticationDetails = new HashMap<>();
-
-            if (authClient != null && authClient.getWebAuthenticationDetails() != null) {
-                webAuthenticationDetails.put("client", authClient.getWebAuthenticationDetails());
+            if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_NONE)) {
+                return;
             }
 
+            // use LinkedHashMap so the serialized audit JSON preserves this insertion order
+            Map<String, Object> data = new LinkedHashMap<>();
+
+            // IP ADDRESS OF CLIENT THAT REQUIRE TOKEN
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL) && authClient != null && authClient.getWebAuthenticationDetails() != null) {
+                data.put("webAuthenticationDetails", authClient.getWebAuthenticationDetails());
+            }
+
+            // CLIENT DATA
+            if (authClient != null) {
+                Map<String, Object> clientData = new LinkedHashMap<>();
+                OAuth2ClientDetails clientDetails = authClient.getOAuth2ClientDetails();
+
+                clientData.put("clientId", authClient.getClientId());
+                clientData.put("realm", clientDetails != null ? clientDetails.getRealm() : realm);
+                clientData.put("clientName", clientDetails != null ? clientDetails.getName() : authClient.getName());
+
+                data.put("client", clientData);
+            }
+
+            // USER DATA
             if (authUser != null && authUser.getDetails() != null) {
-                webAuthenticationDetails.put("user", authUser.getDetails());
+                // Jackson converts to LinkedHashMap, preserving original JSON order
+                Map<String, Object> authUserMap = MAPPER.convertValue(authUser.getDetails(), new TypeReference<>() {});
+
+                if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_FULL)){
+                    data.put("user", authUserMap);
+                } else {
+                    Map<String, Object> userData =  new LinkedHashMap<>();
+                    userData.put("subjectId", authUserMap.get("subjectId"));
+                    userData.put("realm", authUserMap.get("realm"));
+                    userData.put("username", authUserMap.get("username"));
+
+                    if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_DETAILS)){
+                        userData.put("details", extractUserDetails(authUserMap));
+                    }
+                    data.put("user", userData);
+                }
             }
 
-            data.put("webAuthenticationDetails", webAuthenticationDetails);
-
+            String type = auth.getUserAuthentication() == null ? "client" : "user";
             data.put("type", type);
-            data.put("token", token.getValue());
+
+            // TOKEN VALUE SANITIZE
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL)) {
+                String safeTokenValue = sanitizeToken(token.getValue());
+                data.put("token", safeTokenValue);
+            }
+
             data.put("scope", token.getScope());
 
             data.put("jti", token.getToken());
@@ -200,5 +255,69 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
         if (getPublisher() != null) {
             getPublisher().publishEvent(new AuditApplicationEvent(event));
         }
+    }
+
+    // Extracts all account where identities contains principal
+    private static Map<String, Object> extractUserDetails(Map<String, Object> rawDetails) {
+        try {
+            if (rawDetails == null) {
+                return null;
+            }
+            Map<String, Object> safeDetails = new LinkedHashMap<>();
+            Object identitiesObj = rawDetails.get("identities");
+
+            // Process identities if they exist and are in a list format
+            if (identitiesObj instanceof List<?> rawIdentities) {
+                List<Map<String, Object>> safeIdentities = rawIdentities.stream()
+                    .filter(Map.class::isInstance)
+                    .map(Map.class::cast)
+                    // Retain only identities containing both 'principal' and 'account'
+                    .filter(identity -> identity.containsKey("principal") && identity.containsKey("account"))
+                    .map(identity -> {
+                        // Extract and securely map only the 'account' block
+                        Map<String, Object> safeIdentity = new LinkedHashMap<>();
+                        Object accountObj = identity.get("account");
+                        safeIdentity.put("account", MAPPER.convertValue(accountObj, new TypeReference<>() {}));
+                        return safeIdentity;
+                    })
+                    .toList(); // Use .collect(Collectors.toList()) if using Java < 16
+
+                // Attach the sanitized identities to the final result
+                if (!safeIdentities.isEmpty()) {
+                    safeDetails.put("identities", safeIdentities);
+                }
+            }
+            return safeDetails;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error converting details object properties: " + e.getMessage(), e);
+        }
+    }
+
+    private static String sanitizeToken(String tokenValue) {
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            return tokenValue;
+        }
+        int firstDot = tokenValue.indexOf('.');
+        if (firstDot != -1) {
+            int secondDot = tokenValue.indexOf('.', firstDot + 1);
+
+            // Ensure exactly two dots for a valid JWT format
+            if (secondDot != -1 && tokenValue.indexOf('.', secondDot + 1) == -1) {
+                return tokenValue.substring(0, secondDot + 1) + "__SIGNATURE__";
+            }
+        }
+        // Fallback for non-JWT formats
+        return "***MASKED_TOKEN***";
+    }
+
+    private String resolveOauth2EventsLevel(String realm) {
+        if (realmService == null || !StringUtils.hasText(realm)) {
+            return SystemKeys.EVENTS_LEVEL_NONE;
+        }
+        Realm r = realmService.findRealm(realm);
+        String level = (r != null && r.getOAuthConfiguration() != null)
+                ? r.getOAuthConfiguration().getEventsLevel()
+                : null;
+        return StringUtils.hasText(level) ? level : SystemKeys.EVENTS_LEVEL_NONE;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -58,6 +58,7 @@ import it.smartcommunitylab.aac.oauth.token.ResourceOwnerPasswordTokenGranter;
 import it.smartcommunitylab.aac.openid.service.OIDCTokenServices;
 import it.smartcommunitylab.aac.openid.token.IdTokenServices;
 import it.smartcommunitylab.aac.profiles.claims.OpenIdClaimsExtractorProvider;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import it.smartcommunitylab.aac.scope.ScopeRegistry;
 import it.smartcommunitylab.aac.users.service.UserService;
 import java.beans.PropertyVetoException;
@@ -448,7 +449,12 @@ public class OAuth2Config {
     }
 
     @Bean
-    public OAuth2EventListener oauth2EventListener(OAuth2ClientDetailsService clientDetailsService) {
-        return new OAuth2EventListener(clientDetailsService);
+    public OAuth2EventListener oauth2EventListener(
+        OAuth2ClientDetailsService clientDetailsService,
+        RealmService realmService
+    ) {
+        OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
+        listener.setRealmService(realmService);
+        return listener;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.core.model.ConfigurableProperties;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -39,6 +40,10 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
     private Boolean enableClientRegistration;
     private Boolean openClientRegistration;
+
+    // detail level for the OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT)
+    // defaults to none; the listener keeps the default behaviour when not configured
+    private String eventsLevel = SystemKeys.EVENTS_LEVEL_NONE;
 
     public OAuth2ConfigurationMap() {
         enableClientRegistration = false;
@@ -69,6 +74,14 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
         this.openClientRegistration = openClientRegistration;
     }
 
+    public String getEventsLevel() {
+        return eventsLevel;
+    }
+
+    public void setEventsLevel(String eventsLevel) {
+        this.eventsLevel = eventsLevel;
+    }
+
     @Override
     @JsonIgnore
     public Map<String, Serializable> getConfiguration() {
@@ -86,5 +99,6 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
         this.enableClientRegistration = map.getEnableClientRegistration();
         this.openClientRegistration = map.getOpenClientRegistration();
+        this.eventsLevel = map.getEventsLevel();
     }
 }


### PR DESCRIPTION
*This PR is part 2 of a 3-part series aiming to centralize, secure, and make audit log tracking configurable. (Depends on Part 1).*

### What this PR does
It implements the core filtering and security logic for the `TokenGrantEvent` audit logs directly inside `OAuth2EventListener`, utilizing the configuration introduced in Part 1, #800. 

*   **Dynamic Payload Filtering:** Solves the log bloat problem. Based on the Realm's configured level, it controls exactly what gets serialized. The new `extractUserDetails()` method specifically handles the `DETAILS` mode by parsing the user payload and retaining only the identities containing both `principal` and `account` keys.
*   **Token Sanitization:** Aligns with privacy guidelines and RFC 6749/9068. The new `sanitizeToken()` method programmatically strips JWT signatures (replacing them with `__SIGNATURE__`) and fully masks non-JWT formats (`***MASKED_TOKEN***`) to prevent replay attacks if logs are compromised, #805.