### PR TITLE
feat(oauth2): [Part 3/3] Recover user context and propagate grant type in refresh grants

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -342,6 +342,10 @@
         "tokenType": {
             "helperText": "",
             "name": "Token type"
+        },
+        "eventsLevel": {
+            "helperText": "Detail level for OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT) in this realm. Leave empty to keep the default (none).",
+            "name": "OAuth2 token events level"
         }
     },
     "persistence": {

--- a/dev-console/src/myrealms/schemas.ts
+++ b/dev-console/src/myrealms/schemas.ts
@@ -42,6 +42,12 @@ export const realmOAuthSchema: RJSFSchema = {
             title: 'field.oauth2.openClientRegistration.name',
             description: 'field.oauth2.openClientRegistration.helperText',
         },
+        eventsLevel: {
+            type: 'string',
+            enum: ['none', 'minimal', 'details', 'full'],
+            title: 'field.oauth2.eventsLevel.name',
+            description: 'field.oauth2.eventsLevel.helperText',
+        },
     },
 };
 export const realmTosSchema: RJSFSchema = {

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,6 +16,11 @@
 
 package it.smartcommunitylab.aac.audit;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import it.smartcommunitylab.aac.SystemKeys;
+import it.smartcommunitylab.aac.model.Realm;
 import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.event.OAuth2AuthorizationExceptionEvent;
@@ -27,7 +32,11 @@ import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -45,6 +54,8 @@ import org.springframework.util.StringUtils;
 
 public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, ApplicationEventPublisherAware {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public static final String TOKEN_GRANT = "OAUTH2_TOKEN_GRANT";
@@ -52,6 +63,12 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
     private ApplicationEventPublisher publisher;
 
     private final OAuth2ClientDetailsService clientService;
+
+    private RealmService realmService;
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
+    }
 
     public OAuth2EventListener(OAuth2ClientDetailsService clientService) {
         Assert.notNull(clientService, "client service is required");
@@ -149,30 +166,71 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
             OAuth2ClientAuthenticationToken authClient = event.getClientAuthentication();
             Authentication authUser = auth.getUserAuthentication();
 
-            //            String principal = auth.getName();
             String principal = token.getSubject();
             if (!StringUtils.hasText(principal)) {
                 principal = auth.getName();
             }
 
             String realm = token.getRealm();
-            String type = auth.getUserAuthentication() == null ? "client" : "user";
+            // realm level detail configuration
+            String levelRealmEvent = resolveOauth2EventsLevel(realm);
 
-            Map<String, Object> data = new HashMap<>();
-            Map<String, Object> webAuthenticationDetails = new HashMap<>();
-
-            if (authClient != null && authClient.getWebAuthenticationDetails() != null) {
-                webAuthenticationDetails.put("client", authClient.getWebAuthenticationDetails());
+            if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_NONE)) {
+                return;
             }
 
+            // use LinkedHashMap so the serialized audit JSON preserves this insertion order
+            Map<String, Object> data = new LinkedHashMap<>();
+
+            Map<String, Object> oauth2ERequest = MAPPER.convertValue(event.getSource(), new TypeReference<>() {});
+            data.put("grant_type", String.valueOf(oauth2ERequest.get("grantType")));
+
+            // IP ADDRESS OF CLIENT THAT REQUIRE TOKEN
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL) && authClient != null && authClient.getWebAuthenticationDetails() != null) {
+                data.put("webAuthenticationDetails", authClient.getWebAuthenticationDetails());
+            }
+
+            // CLIENT DATA
+            if (authClient != null) {
+                Map<String, Object> clientData = new LinkedHashMap<>();
+                OAuth2ClientDetails clientDetails = authClient.getOAuth2ClientDetails();
+
+                clientData.put("clientId", authClient.getClientId());
+                clientData.put("realm", clientDetails != null ? clientDetails.getRealm() : realm);
+                clientData.put("clientName", clientDetails != null ? clientDetails.getName() : authClient.getName());
+
+                data.put("client", clientData);
+            }
+
+            // USER DATA
             if (authUser != null && authUser.getDetails() != null) {
-                webAuthenticationDetails.put("user", authUser.getDetails());
+                // Jackson converts to LinkedHashMap, preserving original JSON order
+                Map<String, Object> authUserMap = MAPPER.convertValue(authUser.getDetails(), new TypeReference<>() {});
+
+                if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_FULL)){
+                    data.put("user", authUserMap);
+                } else {
+                    Map<String, Object> userData =  new LinkedHashMap<>();
+                    userData.put("subjectId", authUserMap.get("subjectId"));
+                    userData.put("realm", authUserMap.get("realm"));
+                    userData.put("username", authUserMap.get("username"));
+
+                    if(levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_DETAILS)){
+                        userData.put("details", extractUserDetails(authUserMap));
+                    }
+                    data.put("user", userData);
+                }
             }
 
-            data.put("webAuthenticationDetails", webAuthenticationDetails);
-
+            String type = auth.getUserAuthentication() == null ? "client" : "user";
             data.put("type", type);
-            data.put("token", token.getValue());
+
+            // TOKEN VALUE SANITIZE
+            if (!levelRealmEvent.equals(SystemKeys.EVENTS_LEVEL_MINIMAL)) {
+                String safeTokenValue = sanitizeToken(token.getValue());
+                data.put("token", safeTokenValue);
+            }
+
             data.put("scope", token.getScope());
 
             data.put("jti", token.getToken());
@@ -200,5 +258,69 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
         if (getPublisher() != null) {
             getPublisher().publishEvent(new AuditApplicationEvent(event));
         }
+    }
+
+    // Extracts all account where identities contains principal
+    private static Map<String, Object> extractUserDetails(Map<String, Object> rawDetails) {
+        try {
+            if (rawDetails == null) {
+                return null;
+            }
+            Map<String, Object> safeDetails = new LinkedHashMap<>();
+            Object identitiesObj = rawDetails.get("identities");
+
+            // Process identities if they exist and are in a list format
+            if (identitiesObj instanceof List<?> rawIdentities) {
+                List<Map<String, Object>> safeIdentities = rawIdentities.stream()
+                    .filter(Map.class::isInstance)
+                    .map(Map.class::cast)
+                    // Retain only identities containing both 'principal' and 'account'
+                    .filter(identity -> identity.containsKey("principal") && identity.containsKey("account"))
+                    .map(identity -> {
+                        // Extract and securely map only the 'account' block
+                        Map<String, Object> safeIdentity = new LinkedHashMap<>();
+                        Object accountObj = identity.get("account");
+                        safeIdentity.put("account", MAPPER.convertValue(accountObj, new TypeReference<>() {}));
+                        return safeIdentity;
+                    })
+                    .toList(); // Use .collect(Collectors.toList()) if using Java < 16
+
+                // Attach the sanitized identities to the final result
+                if (!safeIdentities.isEmpty()) {
+                    safeDetails.put("identities", safeIdentities);
+                }
+            }
+            return safeDetails;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error converting details object properties: " + e.getMessage(), e);
+        }
+    }
+
+    private static String sanitizeToken(String tokenValue) {
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            return tokenValue;
+        }
+        int firstDot = tokenValue.indexOf('.');
+        if (firstDot != -1) {
+            int secondDot = tokenValue.indexOf('.', firstDot + 1);
+
+            // Ensure exactly two dots for a valid JWT format
+            if (secondDot != -1 && tokenValue.indexOf('.', secondDot + 1) == -1) {
+                return tokenValue.substring(0, secondDot + 1) + "__SIGNATURE__";
+            }
+        }
+        // Fallback for non-JWT formats
+        return "***MASKED_TOKEN***";
+    }
+
+    private String resolveOauth2EventsLevel(String realm) {
+        if (realmService == null || !StringUtils.hasText(realm)) {
+            return SystemKeys.EVENTS_LEVEL_NONE;
+        }
+        Realm r = realmService.findRealm(realm);
+        String level = (r != null && r.getOAuthConfiguration() != null)
+                ? r.getOAuthConfiguration().getEventsLevel()
+                : null;
+        return StringUtils.hasText(level) ? level : SystemKeys.EVENTS_LEVEL_NONE;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -58,6 +58,7 @@ import it.smartcommunitylab.aac.oauth.token.ResourceOwnerPasswordTokenGranter;
 import it.smartcommunitylab.aac.openid.service.OIDCTokenServices;
 import it.smartcommunitylab.aac.openid.token.IdTokenServices;
 import it.smartcommunitylab.aac.profiles.claims.OpenIdClaimsExtractorProvider;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import it.smartcommunitylab.aac.scope.ScopeRegistry;
 import it.smartcommunitylab.aac.users.service.UserService;
 import java.beans.PropertyVetoException;
@@ -321,7 +322,8 @@ public class OAuth2Config {
         ScopeRegistry scopeRegistry,
         UserService userService,
         FlowExtensionsService flowExtensionsService,
-        OAuth2EventPublisher oauth2EventPublisher
+        OAuth2EventPublisher oauth2EventPublisher,
+        ExtTokenStore tokenStore
     ) {
         // build our own list of granters
         List<AbstractTokenGranter> granters = new ArrayList<>();
@@ -357,6 +359,7 @@ public class OAuth2Config {
             oAuth2RequestFactory
         );
         refreshTokenGranter.setEventPublisher(oauth2EventPublisher);
+        refreshTokenGranter.setTokenStore(tokenStore);
         granters.add(refreshTokenGranter);
 
         // implicit
@@ -448,7 +451,12 @@ public class OAuth2Config {
     }
 
     @Bean
-    public OAuth2EventListener oauth2EventListener(OAuth2ClientDetailsService clientDetailsService) {
-        return new OAuth2EventListener(clientDetailsService);
+    public OAuth2EventListener oauth2EventListener(
+            OAuth2ClientDetailsService clientDetailsService,
+            RealmService realmService
+    ) {
+        OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
+        listener.setRealmService(realmService);
+        return listener;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import it.smartcommunitylab.aac.SystemKeys;
 import it.smartcommunitylab.aac.core.model.ConfigurableProperties;
 import java.io.Serializable;
 import java.util.HashMap;
@@ -39,6 +40,10 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
     private Boolean enableClientRegistration;
     private Boolean openClientRegistration;
+
+    // detail level for the OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT)
+    // defaults to none; the listener keeps the default behaviour when not configured
+    private String eventsLevel = SystemKeys.EVENTS_LEVEL_NONE;
 
     public OAuth2ConfigurationMap() {
         enableClientRegistration = false;
@@ -69,6 +74,14 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
         this.openClientRegistration = openClientRegistration;
     }
 
+    public String getEventsLevel() {
+        return eventsLevel;
+    }
+
+    public void setEventsLevel(String eventsLevel) {
+        this.eventsLevel = eventsLevel;
+    }
+
     @Override
     @JsonIgnore
     public Map<String, Serializable> getConfiguration() {
@@ -86,5 +99,6 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
         this.enableClientRegistration = map.getEnableClientRegistration();
         this.openClientRegistration = map.getOpenClientRegistration();
+        this.eventsLevel = map.getEventsLevel();
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
@@ -18,20 +18,31 @@ package it.smartcommunitylab.aac.oauth.token;
 
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
+import it.smartcommunitylab.aac.oauth.store.ExtTokenStore;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class RefreshTokenGranter extends AbstractTokenGranter {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final String GRANT_TYPE = "refresh_token";
+
+    // optional token store, used to recover the full original authentication
+    // (including the end-user) for audit events during the refresh flow
+    private ExtTokenStore tokenStore;
 
     public RefreshTokenGranter(
         AuthorizationServerTokenServices tokenServices,
@@ -74,5 +85,56 @@ public class RefreshTokenGranter extends AbstractTokenGranter {
         String refreshToken = tokenRequest.getRequestParameters().get("refresh_token");
         logger.trace("get access token for refresh token " + refreshToken);
         return getTokenServices().refreshAccessToken(refreshToken, tokenRequest);
+    }
+
+    /*
+     * Recover the full original authentication (including the end-user) bound to the
+     * refresh token. The base implementation builds a client-only authentication with
+     * a null user, which would strip the end-user context from audit events fired for
+     * the refresh_token grant. Falls back to the base behaviour if the authentication
+     * cannot be recovered.
+     */
+    @Override
+    protected OAuth2Authentication getOAuth2Authentication(ClientDetails client, TokenRequest tokenRequest) {
+        if (tokenStore != null) {
+            try {
+                String refreshTokenValue = tokenRequest.getRequestParameters().get("refresh_token");
+                if (refreshTokenValue != null) {
+                    OAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
+                    if (refreshToken != null) {
+                        OAuth2Authentication storedAuth = tokenStore.readAuthenticationForRefreshToken(refreshToken);
+                        if (storedAuth != null && storedAuth.getUserAuthentication() != null) {
+
+                            OAuth2Request pendingOAuth2Request = storedAuth.getOAuth2Request();
+
+                            // Combine original request parameters with the new ones from the token request.
+                            // New parameters will override the old ones in case of clashes.
+                            Map<String, String> combinedParameters = new HashMap<>(
+                                pendingOAuth2Request.getRequestParameters()
+                            );
+                            combinedParameters.putAll(tokenRequest.getRequestParameters());
+
+                            // Create a new OAuth2Request instance using the merged parameters.
+                            // This updates the request context while keeping the original client and scopes.
+                            OAuth2Request finalStoredOAuth2Request = pendingOAuth2Request.createOAuth2Request(combinedParameters);
+
+                            // Retrieve the original user authentication, including the bound accounts.
+                            // This ensures the refreshed token retains the exact same user context.
+                            Authentication userAuth = storedAuth.getUserAuthentication();
+
+                            return new OAuth2Authentication(finalStoredOAuth2Request, userAuth);
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                logger.debug("unable to recover full authentication for refresh token audit event: " + e.getMessage());
+            }
+        }
+
+        return super.getOAuth2Authentication(client, tokenRequest);
+    }
+
+    public void setTokenStore(ExtTokenStore tokenStore) {
+        this.tokenStore = tokenStore;
     }
 }

--- a/src/test/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGrantTest.java
+++ b/src/test/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGrantTest.java
@@ -36,6 +36,8 @@ import it.smartcommunitylab.aac.oauth.model.ClientRegistration;
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
+
+import it.smartcommunitylab.aac.oauth.store.ExtTokenStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +47,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.security.oauth2.core.AuthorizationGrantType;
 import org.springframework.security.oauth2.core.endpoint.OAuth2ParameterNames;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -75,6 +78,9 @@ public class RefreshTokenGrantTest {
 
     @Autowired
     private BootstrapConfig config;
+
+    @Autowired
+    private ExtTokenStore tokenStore;
 
     private String username;
     private String password;
@@ -743,6 +749,100 @@ public class RefreshTokenGrantTest {
 
         // no access token
         assertThat(response.get(OAuth2ParameterNames.ACCESS_TOKEN)).isNull();
+    }
+
+    @Test
+    @WithMockUserAuthentication(username = "test", realm = "test")
+    public void authCodeRefreshShouldPreserveUserAuthenticationTest() throws Exception {
+        // 1. Authorize request to get the authorization code
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add(OAuth2ParameterNames.RESPONSE_TYPE, ResponseType.CODE.toString());
+        params.add(OAuth2ParameterNames.CLIENT_ID, clientId);
+        // Request offline_access to obtain a refresh token
+        List<String> scopes = List.of(Config.SCOPE_OFFLINE_ACCESS, Config.SCOPE_PROFILE);
+        params.add(OAuth2ParameterNames.SCOPE, String.join(" ", scopes));
+
+        MockHttpServletRequestBuilder req = MockMvcRequestBuilders
+            .get(AUTHORIZE_URL)
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .params(params);
+
+        MvcResult res = this.mockMvc.perform(req).andExpect(status().isOk()).andReturn();
+        String forwardedUrl = res.getResponse().getForwardedUrl();
+
+        MockHttpSession session = (MockHttpSession) res.getRequest().getSession();
+        req = MockMvcRequestBuilders.get(forwardedUrl).session(session);
+        res = this.mockMvc.perform(req).andExpect(status().is3xxRedirection()).andReturn();
+
+        String redirectedUrl = res.getResponse().getRedirectedUrl();
+        UriComponentsBuilder builder = UriComponentsBuilder.fromUriString(redirectedUrl);
+        String code = builder.build(true).getQueryParams().get(OAuth2ParameterNames.CODE).get(0);
+        assertThat(code).isNotBlank();
+
+        // 2. Exchange authorization code for Access Token and Refresh Token
+        params = new LinkedMultiValueMap<>();
+        params.add(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.AUTHORIZATION_CODE.getValue());
+        params.add(OAuth2ParameterNames.CODE, code);
+
+        req = MockMvcRequestBuilders
+            .post(TOKEN_URL)
+            .with(httpBasic(clientId, clientSecret))
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .params(params);
+
+        res = this.mockMvc.perform(req).andExpect(status().isOk()).andReturn();
+        Map<String, Serializable> response = mapper.readValue(res.getResponse().getContentAsString(), typeRef);
+
+        String originalAccessToken = (String) response.get(OAuth2ParameterNames.ACCESS_TOKEN);
+        String refreshToken = (String) response.get(OAuth2ParameterNames.REFRESH_TOKEN);
+
+        assertThat(originalAccessToken).isNotBlank();
+        assertThat(refreshToken).isNotBlank();
+
+        // 3. Perform Refresh Token Grant to obtain a new access token
+        params = new LinkedMultiValueMap<>();
+        params.add(OAuth2ParameterNames.GRANT_TYPE, AuthorizationGrantType.REFRESH_TOKEN.getValue());
+        params.add(OAuth2ParameterNames.REFRESH_TOKEN, refreshToken);
+
+        req = MockMvcRequestBuilders
+            .post(TOKEN_URL)
+            .with(httpBasic(clientId, clientSecret))
+            .contentType(MediaType.APPLICATION_FORM_URLENCODED)
+            .params(params);
+
+        res = this.mockMvc.perform(req).andExpect(status().isOk()).andReturn();
+        response = mapper.readValue(res.getResponse().getContentAsString(), typeRef);
+
+        String refreshedAccessToken = (String) response.get(OAuth2ParameterNames.ACCESS_TOKEN);
+        assertThat(refreshedAccessToken).isNotBlank();
+
+        // Read the original authentication bound to the refresh token to get the expected Subject ID
+        org.springframework.security.oauth2.common.OAuth2RefreshToken storedRefreshToken =
+            tokenStore.readRefreshToken(refreshToken);
+        org.springframework.security.oauth2.provider.OAuth2Authentication originalAuth =
+            tokenStore.readAuthenticationForRefreshToken(storedRefreshToken);
+
+        assertThat(originalAuth).isNotNull();
+        assertThat(originalAuth.getUserAuthentication()).isNotNull();
+
+        String expectedSubjectId = originalAuth.getUserAuthentication().getName();
+
+        // Decode the refreshed JWT payload to inspect its claims
+        String[] jwtParts = refreshedAccessToken.split("\\.");
+        assertThat(jwtParts.length).isEqualTo(3);
+
+        String payload = new String(java.util.Base64.getUrlDecoder().decode(jwtParts[1]));
+        Map<String, Serializable> claims = mapper.readValue(payload, typeRef);
+
+        // Verify that the refreshed token retains the exact same user context ('sub' claim)
+        assertThat(claims.get("sub")).isEqualTo(expectedSubjectId);
+
+        // Verify that the realm claim is preserved and matches the original context
+        assertThat(claims.get("realm")).isEqualTo("test");
+
+        // Verify that the scope claims are correctly carried over to the refreshed token
+        assertThat(claims.get("scope")).isNotNull();
+        assertThat(claims.get("scope").toString()).contains(Config.SCOPE_OFFLINE_ACCESS);
     }
 
     private static final String AUTHORIZE_URL = AuthorizationEndpoint.AUTHORIZATION_URL;


### PR DESCRIPTION
*This PR is part 3 of a 3-part series aiming to centralize, secure, and make audit log tracking configurable.*

### What this PR does
It fixes context loss during token renewal flows, ensuring that the audit events triggered contain accurate end-user data and the correct grant type.

*   **User Context Recovery:** Fixes the loss of user data during refresh flows. `RefreshTokenGranter` now utilizes `ExtTokenStore` to trace back the `refresh_token` and recover the complete, original `OAuth2Authentication`, #797. 
*   **Grant Type Propagation:** Explicitly extracts the `grant_type` directly from the `OAuth2Request` parameters to ensure it is accurately propagated to the audit log events.
*   **Testing:** Introduces `authCodeRefreshShouldPreserveUserAuthenticationTest` in `RefreshTokenGrantTest` to explicitly verify that the refreshed token retains the exact same user context (`sub` claim), realm, and scopes.