### PR TITLE
feat(audit): implement OAuth2 events level and preserve refresh token context

### DIFF
--- a/dev-console/src/i18n/en/fields.json
+++ b/dev-console/src/i18n/en/fields.json
@@ -342,6 +342,10 @@
         "tokenType": {
             "helperText": "",
             "name": "Token type"
+        },
+        "eventsLevel": {
+            "helperText": "Detail level for OAuth2 token grant audit events (OAUTH2_TOKEN_GRANT) in this realm. Leave empty to keep the default (minimal).",
+            "name": "OAuth2 token events level"
         }
     },
     "persistence": {

--- a/dev-console/src/myrealms/schemas.ts
+++ b/dev-console/src/myrealms/schemas.ts
@@ -42,6 +42,12 @@ export const realmOAuthSchema: RJSFSchema = {
             title: 'field.oauth2.openClientRegistration.name',
             description: 'field.oauth2.openClientRegistration.helperText',
         },
+        eventsLevel: {
+            type: 'string',
+            enum: ['none', 'minimal', 'details', 'full'],
+            title: 'field.oauth2.eventsLevel.name',
+            description: 'field.oauth2.eventsLevel.helperText',
+        },
     },
 };
 export const realmTosSchema: RJSFSchema = {

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,6 +16,13 @@
 
 package it.smartcommunitylab.aac.audit;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import it.smartcommunitylab.aac.core.UserDetails;
+import it.smartcommunitylab.aac.core.auth.UserAuthentication;
+import it.smartcommunitylab.aac.identity.model.UserIdentity;
+import it.smartcommunitylab.aac.model.EventsLevel;
+import it.smartcommunitylab.aac.model.Realm;
 import it.smartcommunitylab.aac.oauth.AACOAuth2AccessToken;
 import it.smartcommunitylab.aac.oauth.auth.OAuth2ClientAuthenticationToken;
 import it.smartcommunitylab.aac.oauth.event.OAuth2AuthorizationExceptionEvent;
@@ -23,11 +30,21 @@ import it.smartcommunitylab.aac.oauth.event.OAuth2Event;
 import it.smartcommunitylab.aac.oauth.event.OAuth2TokenExceptionEvent;
 import it.smartcommunitylab.aac.oauth.event.TokenGrantEvent;
 import it.smartcommunitylab.aac.oauth.model.OAuth2ClientDetails;
+import it.smartcommunitylab.aac.oauth.model.OAuth2ConfigurationMap;
 import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
+
+import java.io.Serializable;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
@@ -45,6 +62,8 @@ import org.springframework.util.StringUtils;
 
 public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, ApplicationEventPublisherAware {
 
+    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     public static final String TOKEN_GRANT = "OAUTH2_TOKEN_GRANT";
@@ -52,6 +71,14 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
     private ApplicationEventPublisher publisher;
 
     private final OAuth2ClientDetailsService clientService;
+
+    private RealmService realmService;
+
+    private static final EventsLevel DEFAULT_EVENTS_LEVEL = EventsLevel.MINIMAL;
+
+    public void setRealmService(RealmService realmService) {
+        this.realmService = realmService;
+    }
 
     public OAuth2EventListener(OAuth2ClientDetailsService clientService) {
         Assert.notNull(clientService, "client service is required");
@@ -149,30 +176,72 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
             OAuth2ClientAuthenticationToken authClient = event.getClientAuthentication();
             Authentication authUser = auth.getUserAuthentication();
 
-            //            String principal = auth.getName();
             String principal = token.getSubject();
             if (!StringUtils.hasText(principal)) {
                 principal = auth.getName();
             }
 
             String realm = token.getRealm();
+            // realm level detail configuration
+            EventsLevel levelRealmEvent = resolveOauth2EventsLevel(realm);
+
+            if (EventsLevel.NONE.equals(levelRealmEvent)) {
+                return;
+            }
+
+            // use LinkedHashMap so the serialized audit JSON preserves this insertion order
+            Map<String, Object> data = new LinkedHashMap<>();
+
+            if(auth.getOAuth2Request() != null) {
+                String grantType = auth.getOAuth2Request().getGrantType();
+                data.put("grant_type", grantType);
+            }
+
+            // IP ADDRESS OF CLIENT THAT REQUIRE TOKEN
+            if(!EventsLevel.MINIMAL.equals(levelRealmEvent) && authClient != null && authClient.getWebAuthenticationDetails() != null) {
+                data.put("webAuthenticationDetails", authClient.getWebAuthenticationDetails());
+            }
+
+            // CLIENT DATA
+            if (authClient != null) {
+                Map<String, Object> clientData = new LinkedHashMap<>();
+                OAuth2ClientDetails clientDetails = authClient.getOAuth2ClientDetails();
+
+                clientData.put("clientId", authClient.getClientId());
+                clientData.put("realm", clientDetails != null ? clientDetails.getRealm() : realm);
+                clientData.put("clientName", clientDetails != null ? clientDetails.getName() : authClient.getName());
+
+                data.put("client", clientData);
+            }
+
+            // USER DATA
+            if (authUser instanceof UserAuthentication userAuthentication) {
+                UserDetails userDetails = userAuthentication.getUser();
+
+                if(EventsLevel.FULL.equals(levelRealmEvent)){
+                    data.put("user", userDetails);
+                } else {
+                    Map<String, Object> userData =  new LinkedHashMap<>();
+                    userData.put("subjectId", userDetails.getSubjectId());
+                    userData.put("realm", userDetails.getRealm());
+                    userData.put("username", userDetails.getUsername());
+
+                    if(EventsLevel.DETAILS.equals(levelRealmEvent)){
+                        userData.put("details", extractUserPrincipalAccounts(userDetails.getIdentities()));
+                    }
+                    data.put("user", userData);
+                }
+            }
+
             String type = auth.getUserAuthentication() == null ? "client" : "user";
-
-            Map<String, Object> data = new HashMap<>();
-            Map<String, Object> webAuthenticationDetails = new HashMap<>();
-
-            if (authClient != null && authClient.getWebAuthenticationDetails() != null) {
-                webAuthenticationDetails.put("client", authClient.getWebAuthenticationDetails());
-            }
-
-            if (authUser != null && authUser.getDetails() != null) {
-                webAuthenticationDetails.put("user", authUser.getDetails());
-            }
-
-            data.put("webAuthenticationDetails", webAuthenticationDetails);
-
             data.put("type", type);
-            data.put("token", token.getValue());
+
+            // TOKEN VALUE SANITIZE
+            if(!EventsLevel.MINIMAL.equals(levelRealmEvent)) {
+                String safeTokenValue = sanitizeToken(token.getValue());
+                data.put("token", safeTokenValue);
+            }
+
             data.put("scope", token.getScope());
 
             data.put("jti", token.getToken());
@@ -200,5 +269,65 @@ public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, Ap
         if (getPublisher() != null) {
             getPublisher().publishEvent(new AuditApplicationEvent(event));
         }
+    }
+
+    // Extracts all account where identities contains principal
+    private static Map<String, Serializable> extractUserPrincipalAccounts(Collection<UserIdentity> rawIdentities) {
+        try {
+            // Early exit guard
+            if (rawIdentities == null || rawIdentities.isEmpty()) {
+                return null;
+            }
+            List<Map<String, Serializable>> safeIdentities = new ArrayList<>();
+
+            // Process identities directly
+            for (UserIdentity identity : rawIdentities) {
+                if (identity != null && identity.getPrincipal() != null && identity.getAccount() != null) {
+                    Map<String, Serializable> safeIdentity = new LinkedHashMap<>();
+
+                    // Put the entire account object directly
+                    safeIdentity.put("account", identity.getAccount());
+                    safeIdentities.add(safeIdentity);
+                }
+            }
+
+            // Wrap the list inside the expected "identities" root map
+            Map<String, Serializable> safeDetails = new LinkedHashMap<>();
+            if (!safeIdentities.isEmpty()) {
+                safeDetails.put("identities", (Serializable) safeIdentities);
+            }
+
+            return safeDetails;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Error converting details object properties: " + e.getMessage(), e);
+        }
+    }
+
+    private static String sanitizeToken(String tokenValue) {
+        if (tokenValue == null || tokenValue.isEmpty()) {
+            return tokenValue;
+        }
+        int firstDot = tokenValue.indexOf('.');
+        if (firstDot != -1) {
+            int secondDot = tokenValue.indexOf('.', firstDot + 1);
+
+            // Ensure exactly two dots for a valid JWT format
+            if (secondDot != -1 && tokenValue.indexOf('.', secondDot + 1) == -1) {
+                return tokenValue.substring(0, secondDot + 1) + "__SIGNATURE__";
+            }
+        }
+        // Fallback for non-JWT formats
+        return "***MASKED_TOKEN***";
+    }
+
+    private EventsLevel resolveOauth2EventsLevel(String realm) {
+        if (realmService == null || !StringUtils.hasText(realm)) {
+            return DEFAULT_EVENTS_LEVEL;
+        }
+
+        return Optional.ofNullable(realmService.findRealm(realm))
+            .map(Realm::getOAuthConfiguration)
+            .map(OAuth2ConfigurationMap::getEventsLevel)
+            .orElse(DEFAULT_EVENTS_LEVEL);
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
+++ b/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java
@@ -16,8 +16,6 @@
 
 package it.smartcommunitylab.aac.audit;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import it.smartcommunitylab.aac.core.UserDetails;
 import it.smartcommunitylab.aac.core.auth.UserAuthentication;
 import it.smartcommunitylab.aac.identity.model.UserIdentity;
@@ -61,8 +59,6 @@ import org.springframework.util.Assert;
 import org.springframework.util.StringUtils;
 
 public class OAuth2EventListener implements ApplicationListener<OAuth2Event>, ApplicationEventPublisherAware {
-
-    private static final ObjectMapper MAPPER = new ObjectMapper().registerModule(new JavaTimeModule());
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -58,6 +58,7 @@ import it.smartcommunitylab.aac.oauth.token.ResourceOwnerPasswordTokenGranter;
 import it.smartcommunitylab.aac.openid.service.OIDCTokenServices;
 import it.smartcommunitylab.aac.openid.token.IdTokenServices;
 import it.smartcommunitylab.aac.profiles.claims.OpenIdClaimsExtractorProvider;
+import it.smartcommunitylab.aac.realms.service.RealmService;
 import it.smartcommunitylab.aac.scope.ScopeRegistry;
 import it.smartcommunitylab.aac.users.service.UserService;
 import java.beans.PropertyVetoException;
@@ -321,7 +322,8 @@ public class OAuth2Config {
         ScopeRegistry scopeRegistry,
         UserService userService,
         FlowExtensionsService flowExtensionsService,
-        OAuth2EventPublisher oauth2EventPublisher
+        OAuth2EventPublisher oauth2EventPublisher,
+        ExtTokenStore tokenStore
     ) {
         // build our own list of granters
         List<AbstractTokenGranter> granters = new ArrayList<>();
@@ -357,6 +359,7 @@ public class OAuth2Config {
             oAuth2RequestFactory
         );
         refreshTokenGranter.setEventPublisher(oauth2EventPublisher);
+        refreshTokenGranter.setTokenStore(tokenStore);
         granters.add(refreshTokenGranter);
 
         // implicit
@@ -448,7 +451,12 @@ public class OAuth2Config {
     }
 
     @Bean
-    public OAuth2EventListener oauth2EventListener(OAuth2ClientDetailsService clientDetailsService) {
-        return new OAuth2EventListener(clientDetailsService);
+    public OAuth2EventListener oauth2EventListener(
+            OAuth2ClientDetailsService clientDetailsService,
+            RealmService realmService
+    ) {
+        OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
+        listener.setRealmService(realmService);
+        return listener;
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
+++ b/src/main/java/it/smartcommunitylab/aac/config/OAuth2Config.java
@@ -81,6 +81,7 @@ import org.springframework.security.oauth2.provider.approval.ApprovalStore;
 import org.springframework.security.oauth2.provider.code.AuthorizationCodeServices;
 import org.springframework.security.oauth2.provider.endpoint.RedirectResolver;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
+import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.web.bind.support.DefaultSessionAttributeStore;
 import org.springframework.web.bind.support.SessionAttributeStore;
 import org.springframework.web.context.WebApplicationContext;
@@ -323,7 +324,7 @@ public class OAuth2Config {
         UserService userService,
         FlowExtensionsService flowExtensionsService,
         OAuth2EventPublisher oauth2EventPublisher,
-        ExtTokenStore tokenStore
+        TokenStore tokenStore
     ) {
         // build our own list of granters
         List<AbstractTokenGranter> granters = new ArrayList<>();
@@ -452,8 +453,8 @@ public class OAuth2Config {
 
     @Bean
     public OAuth2EventListener oauth2EventListener(
-            OAuth2ClientDetailsService clientDetailsService,
-            RealmService realmService
+        OAuth2ClientDetailsService clientDetailsService,
+        RealmService realmService
     ) {
         OAuth2EventListener listener = new OAuth2EventListener(clientDetailsService);
         listener.setRealmService(realmService);

--- a/src/main/java/it/smartcommunitylab/aac/model/EventsLevel.java
+++ b/src/main/java/it/smartcommunitylab/aac/model/EventsLevel.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2023 the original author or authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package it.smartcommunitylab.aac.model;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.springframework.util.Assert;
+
+public enum EventsLevel {
+    NONE("none"),
+    MINIMAL("minimal"),
+    DETAILS("details"),
+    FULL("full");
+
+    private final String value;
+
+    EventsLevel(String value) {
+        Assert.hasText(value, "value cannot be empty");
+        this.value = value;
+    }
+
+    @JsonValue
+    public String getValue() {
+        return value;
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    public static EventsLevel parse(String value) {
+        for (EventsLevel el : EventsLevel.values()) {
+            if (el.value.equalsIgnoreCase(value)) {
+                return el;
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/model/OAuth2ConfigurationMap.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import it.smartcommunitylab.aac.core.model.ConfigurableProperties;
+import it.smartcommunitylab.aac.model.EventsLevel;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
@@ -39,6 +40,7 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
     private Boolean enableClientRegistration;
     private Boolean openClientRegistration;
+    private EventsLevel eventsLevel;
 
     public OAuth2ConfigurationMap() {
         enableClientRegistration = false;
@@ -69,6 +71,14 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
         this.openClientRegistration = openClientRegistration;
     }
 
+    public EventsLevel getEventsLevel() {
+        return eventsLevel;
+    }
+
+    public void setEventsLevel(EventsLevel eventsLevel) {
+        this.eventsLevel = eventsLevel;
+    }
+
     @Override
     @JsonIgnore
     public Map<String, Serializable> getConfiguration() {
@@ -86,5 +96,6 @@ public class OAuth2ConfigurationMap implements ConfigurableProperties {
 
         this.enableClientRegistration = map.getEnableClientRegistration();
         this.openClientRegistration = map.getOpenClientRegistration();
+        this.eventsLevel = map.getEventsLevel();
     }
 }

--- a/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
+++ b/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java
@@ -21,17 +21,24 @@ import it.smartcommunitylab.aac.oauth.service.OAuth2ClientDetailsService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
+import org.springframework.security.oauth2.common.OAuth2RefreshToken;
 import org.springframework.security.oauth2.provider.ClientDetails;
 import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.OAuth2RequestFactory;
 import org.springframework.security.oauth2.provider.TokenRequest;
 import org.springframework.security.oauth2.provider.token.AuthorizationServerTokenServices;
+import org.springframework.security.oauth2.provider.token.TokenStore;
+
 
 public class RefreshTokenGranter extends AbstractTokenGranter {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private static final String GRANT_TYPE = "refresh_token";
+
+    // optional token store, used to recover the full original authentication
+    // (including the end-user) for audit events during the refresh flow
+    private TokenStore tokenStore;
 
     public RefreshTokenGranter(
         AuthorizationServerTokenServices tokenServices,
@@ -74,5 +81,49 @@ public class RefreshTokenGranter extends AbstractTokenGranter {
         String refreshToken = tokenRequest.getRequestParameters().get("refresh_token");
         logger.trace("get access token for refresh token " + refreshToken);
         return getTokenServices().refreshAccessToken(refreshToken, tokenRequest);
+    }
+
+    /*
+     * Overrides the base behavior to recover the full original authentication (including the end-user)
+     * bound to the refresh token.
+     * The default implementation in AbstractTokenGranter returns an OAuth2Authentication with a null user.
+     * We intercept this to attach the historical userAuthentication retrieved from the TokenStore,
+     * ensuring the refreshed token retains the exact same user context for audit events and token enhancement.
+     */
+    @Override
+    protected OAuth2Authentication getOAuth2Authentication(ClientDetails client, TokenRequest tokenRequest) {
+        // 1. Get the base client-only authentication from the framework (user is null here)
+        OAuth2Authentication oAuth2Authentication = super.getOAuth2Authentication(client, tokenRequest);
+
+        // Early exit if tokenStore is not configured
+        if (tokenStore == null) {
+            return oAuth2Authentication;
+        }
+
+        try {
+            String refreshTokenValue = tokenRequest.getRequestParameters().get("refresh_token");
+            if (refreshTokenValue != null) {
+                OAuth2RefreshToken refreshToken = tokenStore.readRefreshToken(refreshTokenValue);
+                if (refreshToken != null) {
+
+                    // 2. Retrieve the historical authentication from the store
+                    OAuth2Authentication storedAuth = tokenStore.readAuthenticationForRefreshToken(refreshToken);
+
+                    if (storedAuth != null && storedAuth.getUserAuthentication() != null) {
+                        // 3. Attach the recovered user authentication to the current request
+                        return new OAuth2Authentication(oAuth2Authentication.getOAuth2Request(), storedAuth.getUserAuthentication());
+                    }
+                }
+            }
+        } catch (Exception e) {
+            logger.debug("unable to recover full authentication for refresh token audit event: " + e.getMessage());
+        }
+
+        // Fallback to base behavior if user recovery fails
+        return oAuth2Authentication;
+    }
+
+    public void setTokenStore(TokenStore tokenStore) {
+        this.tokenStore = tokenStore;
     }
 }


### PR DESCRIPTION
### Overview
This PR unifies multiple interdependent issues to centralize, secure, and make the audit log tracking (`TokenGrantEvent`) fully configurable. It introduces dynamic log verbosity per Realm, secures logged tokens against replay attacks, and fixes user context loss during token refresh flows.

### 1. Dynamic Audit Level Configuration & Enum (Closes #800)
It introduces the core configuration layer to allow administrators to dynamically set the OAuth2 audit log verbosity directly from the UI for each individual Realm.

*   **Core & Enum:** Introduces the `EventsLevel` enum to precisely define the logging tiers (`NONE`, `MINIMAL`, `DETAILS`, `FULL`), replacing string literals for stricter type safety.
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/model/EventsLevel.java#L22-L26
*   **Backend:** Updates `OAuth2ConfigurationMap` and `OAuth2Config` to store the new audit configuration. In `OAuth2EventListener`, it introduces the `resolveOauth2EventsLevel()` method leveraging `RealmService` to read the configuration, gracefully defaulting to `NONE`.
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java#L323-L331
*   **Frontend (React):** Exposes a dropdown menu with 4 incremental levels: `none`, `minimal`, `details`, and `full` in the Realm configuration.
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/dev-console/src/myrealms/schemas.ts#L45-L50

### 2. Dynamic Payload Filtering & Sanitization (Closes #800, Closes #805)
It implements the core filtering and security logic for the `TokenGrantEvent` audit logs directly inside `OAuth2EventListener`, utilizing the configured `EventsLevel`.

*   **Dynamic Payload Filtering:** Solves the log bloat problem. Based on the Realm's configured level, it controls exactly what gets serialized. The new `extractUserDetails()` method specifically handles the `DETAILS` mode by parsing the user payload and retaining only the identities containing both `principal` and `account` keys.
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java#L283-L292
*   **Token Sanitization:** Aligns with privacy guidelines and RFC 6749/9068. The new `sanitizeToken()` method programmatically strips JWT signatures (replacing them with `__SIGNATURE__`) and fully masks non-JWT formats (`***MASKED_TOKEN***`) to prevent replay attacks if logs are compromised.
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java#L306-L321

### 3. User Context Recovery & Grant Tracking (Closes #797)
It fixes context loss during token renewal flows, ensuring that the audit events triggered contain accurate end-user data and the correct grant type.

*   **User Context Recovery:** Fixes the loss of user data during refresh flows. `RefreshTokenGranter` now utilizes `ExtTokenStore` to trace back the `refresh_token` and recover the complete, original `OAuth2Authentication`. 
https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/oauth/token/RefreshTokenGranter.java#L101-L128
*   **Grant Type Propagation:** Explicitly extracts the `grant_type` directly from the `OAuth2Request` parameters to ensure it is accurately propagated to the audit log events.
 https://github.com/scc-digitalhub/AAC/blob/aafa39a4c3b52027ef9a4e2be531e2530c3146e6/src/main/java/it/smartcommunitylab/aac/audit/OAuth2EventListener.java#L189-L190